### PR TITLE
Turn AttData into trait and optimize response encoding

### DIFF
--- a/bleps-macros/src/lib.rs
+++ b/bleps-macros/src/lib.rs
@@ -6,15 +6,23 @@ use syn::{parse_macro_input, Expr, Lit, Member, Path};
 ///
 /// ```no-execute
 /// gatt!([
-/// service {
-///     uuid: "9e7312e0-2354-11eb-9f10-fbc30a62cf38",
-///     characteristics: [
-///         characteristic {
-///              uuid: "9e7312e0-2354-11eb-9f10-fbc30a62cf38",
-///              read: my_read_function,
-///              write: my_write_function,
-///         },
-///     ],
+///     service {
+///         uuid: "9e7312e0-2354-11eb-9f10-fbc30a62cf38",
+///         characteristics: [
+///             characteristic {
+///                 uuid: "ed5a3953-8ea8-4e0c-9675-044de805a719",
+///                 read: my_read_function,
+///                 write: my_write_function,
+///                 name: "characteristic1",
+///                 description: "Characteristic accessible via functions",
+///             },
+///             characteristic {
+///                 uuid: "96c05dff-2ff0-4080-ab41-f4d24bc6da85",
+///                 value: my_data,
+///                 name: "characteristic2",
+///                 description: "Characteristic with value which implements AttData",
+///             },
+///         ],
 ///     },
 /// ]);
 /// ```
@@ -32,10 +40,7 @@ pub fn gatt(input: TokenStream) -> TokenStream {
                     return quote! { compile_error!("Unexpected"); }.into();
                 }
 
-                let mut service = Service {
-                    uuid: String::new(),
-                    characteristics: Vec::new(),
-                };
+                let mut service = Service::default();
 
                 for field in s.fields {
                     let name = if let Member::Named(name) = field.member {
@@ -64,14 +69,7 @@ pub fn gatt(input: TokenStream) -> TokenStream {
                                             return quote! { compile_error!("Unexpected"); }.into();
                                         }
 
-                                        let mut charact = Characteristic {
-                                            uuid: String::new(),
-                                            read: None,
-                                            write: None,
-                                            description: None,
-                                            notify: false,
-                                            name: None,
-                                        };
+                                        let mut charact = Characteristic::default();
 
                                         for field in s.fields {
                                             let name = if let Member::Named(name) = field.member {
@@ -89,6 +87,22 @@ pub fn gatt(input: TokenStream) -> TokenStream {
                                                         } else {
                                                             return quote!{ compile_error!("Unexpected"); }.into();
                                                         }
+                                                    } else {
+                                                        return quote!{ compile_error!("Unexpected"); }.into();
+                                                    }
+                                                }
+                                                "data" => {
+                                                    if let Expr::Path(p) = field.expr {
+                                                        let name = path_to_string(p.path);
+                                                        charact.data = Some(name);
+                                                    } else {
+                                                        return quote!{ compile_error!("Unexpected"); }.into();
+                                                    }
+                                                }
+                                                "value" => {
+                                                    if let Expr::Path(p) = field.expr {
+                                                        let name = path_to_string(p.path);
+                                                        charact.value = Some(name);
                                                     } else {
                                                         return quote!{ compile_error!("Unexpected"); }.into();
                                                     }
@@ -180,7 +194,7 @@ pub fn gatt(input: TokenStream) -> TokenStream {
         decls.push(quote!(let #uuid_ident = [ #(#uuid_bytes),* ] ;));
 
         let uuid_data = format_ident!("_uuid_data{}", i);
-        decls.push(quote!(let mut #uuid_data = AttData::Static(&#uuid_ident);));
+        decls.push(quote!(let mut #uuid_data = &#uuid_ident;));
 
         let primary_service_ident = format_ident!("_primary_srv{}", i);
         decls.push(
@@ -212,7 +226,7 @@ pub fn gatt(input: TokenStream) -> TokenStream {
             decls.push(quote!(let #char_data_ident = [ #(#char_data),* ] ;));
 
             let char_data_attr = format_ident!("_char_data_attr{}{}", i, j);
-            decls.push(quote!(let mut #char_data_attr = AttData::Static(&#char_data_ident);));
+            decls.push(quote!(let mut #char_data_attr = &#char_data_ident;));
 
             let char_data_attribute = format_ident!("_char_data_attribute{}{}", i, j);
             decls.push(
@@ -223,33 +237,46 @@ pub fn gatt(input: TokenStream) -> TokenStream {
 
             let gen_attr_att_data_ident = format_ident!("_gen_attr_att_data{}{}", i, j);
 
-            let rfunction = if characteristic.read.is_none() {
-                quote!(None)
-            } else {
-                let fname = format_ident!("{}", characteristic.read.as_ref().unwrap());
-                quote!(Some(&mut #fname))
-            };
-            let wfunction = if characteristic.write.is_none() {
-                quote!(None)
-            } else {
-                let fname = format_ident!("{}", characteristic.write.as_ref().unwrap());
-                quote!(Some(&mut #fname))
-            };
-
             decls.push(
-                quote!(let mut #gen_attr_att_data_ident = AttData::Dynamic { read_function: #rfunction, write_function: #wfunction};)
+                if characteristic.read.is_some() || characteristic.write.is_some() {
+                    let rfunction = if let Some(name) = &characteristic.read {
+                        let fname = format_ident!("{}", name);
+                        quote!(&mut #fname)
+                    } else {
+                        quote!(())
+                    };
+
+                    let wfunction = if let Some(name) = &characteristic.write {
+                        let fname = format_ident!("{}", name);
+                        quote!(&mut #fname)
+                    } else {
+                        quote!(())
+                    };
+
+                    quote!(let mut #gen_attr_att_data_ident = (#rfunction, #wfunction);)
+                } else if let Some(name) = &characteristic.value {
+                    let vname = format_ident!("{}", name);
+                    quote!(let mut #gen_attr_att_data_ident = (#vname,);)
+                } else if let Some(name) = &characteristic.data {
+                    let dname = format_ident!("{}", name);
+                    quote!(let mut #gen_attr_att_data_ident = (#dname,);)
+                } else {
+                    quote!(compile_error!(
+                        "Characteristic data fields missing: 'read'/'write' nor 'value' nor 'data'"
+                    ))
+                },
             );
 
             let gen_attr_ident = format_ident!("_gen_attr{}{}", i, j);
-            if uuid_bytes.len() == 2 {
-                decls.push(
-                    quote!(let #gen_attr_ident = Attribute::new(Uuid::Uuid16( u16::from_le_bytes([ #(#uuid_bytes),* ])), &mut #gen_attr_att_data_ident);)
-                );
+            let gen_attr_att_uuid = if uuid_bytes.len() == 2 {
+                quote!(Uuid::Uuid16(u16::from_le_bytes([ #(#uuid_bytes),* ])))
             } else {
-                decls.push(
-                    quote!(let #gen_attr_ident = Attribute::new(Uuid::Uuid128([ #(#uuid_bytes),* ]), &mut #gen_attr_att_data_ident);)
-                );
-            }
+                quote!(Uuid::Uuid128([ #(#uuid_bytes),* ]))
+            };
+
+            decls.push(
+                quote!(let #gen_attr_ident = Attribute::new(#gen_attr_att_uuid, &mut #gen_attr_att_data_ident);)
+            );
             attribs.push(quote!(#gen_attr_ident));
             current_handle += 1;
 
@@ -263,7 +290,7 @@ pub fn gatt(input: TokenStream) -> TokenStream {
 
                 let char_user_description_data_attr =
                     format_ident!("_char_user_description_data_attr{}{}", i, j);
-                decls.push(quote!(let mut #char_user_description_data_attr = AttData::Static(&#char_user_description_data_ident);));
+                decls.push(quote!(let mut #char_user_description_data_attr = &#char_user_description_data_ident;));
 
                 let char_user_description_data_attribute =
                     format_ident!("_char_user_description_data_attribute{}{}", i, j);
@@ -283,10 +310,9 @@ pub fn gatt(input: TokenStream) -> TokenStream {
                 let char_ccd_data_attr = format_ident!("_char_ccd_data_attr{}{}", i, j);
                 let rfunction = format_ident!("_attr_read{}", current_handle);
                 let wfunction = format_ident!("_attr_write{}", current_handle);
-                decls.push(quote!(let mut #char_ccd_data_attr = AttData::Dynamic {
-                        read_function: Some(&mut #rfunction),
-                        write_function: Some(&mut #wfunction)
-                    };));
+                decls.push(
+                    quote!(let mut #char_ccd_data_attr = (&mut #rfunction, &mut #wfunction);),
+                );
 
                 let backing_data = format_ident!("_attr_data{}", current_handle);
                 pre.push(quote!(
@@ -358,8 +384,7 @@ pub fn gatt(input: TokenStream) -> TokenStream {
     let code = quote! {
         use bleps::Data;
         use bleps::att::Uuid;
-        use bleps::attribute_server::AttData;
-        use bleps::attribute_server::Attribute;
+        use bleps::attribute::Attribute;
         use bleps::attribute_server::CHARACTERISTIC_UUID16;
         use bleps::attribute_server::PRIMARY_SERVICE_UUID16;
 
@@ -395,15 +420,17 @@ fn uuid_to_bytes(uuid: &str) -> Vec<u8> {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct Service {
     uuid: String,
     characteristics: Vec<Characteristic>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 struct Characteristic {
     uuid: String,
+    data: Option<String>,
+    value: Option<String>,
     read: Option<String>,
     write: Option<String>,
     description: Option<String>,

--- a/bleps-macros/src/lib.rs
+++ b/bleps-macros/src/lib.rs
@@ -292,7 +292,7 @@ pub fn gatt(input: TokenStream) -> TokenStream {
                 pre.push(quote!(
                     static mut #backing_data: [u8; 2] = [0u8; 2];
 
-                    let mut #rfunction = |offset: u16, data: &mut [u8]| {
+                    let mut #rfunction = |offset: usize, data: &mut [u8]| {
                         let off = offset as usize;
                         unsafe {
                             if off < #backing_data.len() {
@@ -306,7 +306,7 @@ pub fn gatt(input: TokenStream) -> TokenStream {
                         }
                         0
                     };
-                    let mut #wfunction = |offset: u16, data: &[u8]| {
+                    let mut #wfunction = |offset: usize, data: &[u8]| {
                         let off = offset as usize;
                         unsafe {
                             if off < #backing_data.len() {

--- a/bleps/src/acl.rs
+++ b/bleps/src/acl.rs
@@ -61,10 +61,10 @@ pub fn parse_acl_packet(connector: &dyn HciConnection) -> AclPacket {
     let data = read_to_data(connector, len as usize);
 
     AclPacket {
-        handle: handle,
+        handle,
         boundary_flag: pb,
         bc_flag: bc,
-        data: data,
+        data,
     }
 }
 
@@ -103,10 +103,10 @@ where
     let data = crate::asynch::read_to_data(connector, len as usize).await;
 
     AclPacket {
-        handle: handle,
+        handle,
         boundary_flag: pb,
         bc_flag: bc,
-        data: data,
+        data,
     }
 }
 
@@ -142,7 +142,7 @@ pub fn encode_acl_packet(
     let len = payload.len;
     data.append(&[(len & 0xff) as u8, ((len >> 8) & 0xff) as u8]);
 
-    data.append(payload.to_slice());
+    data.append(payload.as_slice());
 
     data
 }

--- a/bleps/src/async_attribute_server.rs
+++ b/bleps/src/async_attribute_server.rs
@@ -81,7 +81,7 @@ where
                 ..
             } => {
                 if let Some(rf) = read_function {
-                    Some((&mut *rf)(offset, buffer))
+                    Some((&mut *rf)(offset as usize, buffer))
                 } else {
                     None
                 }
@@ -553,7 +553,7 @@ where
                         ..
                     } => {
                         if let Some(wf) = write_function {
-                            (&mut *wf)(offset, value.as_slice());
+                            (&mut *wf)(offset as usize, value.as_slice());
                         }
                     }
                 };
@@ -598,7 +598,7 @@ where
                         ..
                     } => {
                         if let Some(rf) = read_function {
-                            let len = (&mut *rf)(offset, data.as_slice_mut());
+                            let len = (&mut *rf)(offset as usize, data.as_slice_mut());
                             data.append_len(len);
                         }
                     }

--- a/bleps/src/att.rs
+++ b/bleps/src/att.rs
@@ -31,22 +31,20 @@ pub enum Uuid {
     Uuid128([u8; 16]),
 }
 
-impl Uuid {
-    pub(crate) fn encode(&self) -> Data {
-        let mut data = Data::default();
-
-        match self {
+impl Data {
+    pub fn append_uuid(&mut self, uuid: &Uuid) {
+        match uuid {
             Uuid::Uuid16(uuid) => {
-                data.append(&[(uuid & 0xff) as u8, ((uuid >> 8) & 0xff) as u8]);
+                self.append_value(*uuid);
             }
             Uuid::Uuid128(uuid) => {
-                let bytes = uuid.clone();
-                data.append(&bytes);
+                self.append(&uuid[..]);
             }
         }
-        data
     }
+}
 
+impl Uuid {
     pub fn bytes(&self, data: &mut [u8]) {
         match self {
             Uuid::Uuid16(uuid) => data.copy_from_slice(&uuid.to_be_bytes()),
@@ -60,14 +58,21 @@ impl Uuid {
             Uuid::Uuid128(_) => 0x02,
         }
     }
+
+    pub fn len(&self) -> usize {
+        match self {
+            Uuid::Uuid16(_) => 6,
+            Uuid::Uuid128(_) => 20,
+        }
+    }
 }
 
 impl From<Data> for Uuid {
     fn from(data: Data) -> Self {
         match data.len() {
-            2 => Uuid::Uuid16(u16::from_le_bytes(data.to_slice().try_into().unwrap())),
+            2 => Uuid::Uuid16(u16::from_le_bytes(data.as_slice().try_into().unwrap())),
             16 => {
-                let bytes: [u8; 16] = data.to_slice().try_into().unwrap();
+                let bytes: [u8; 16] = data.as_slice().try_into().unwrap();
                 Uuid::Uuid128(bytes)
             }
             _ => panic!(),
@@ -180,8 +185,8 @@ pub enum AttParseError {
 }
 
 pub fn parse_att(packet: L2capPacket) -> Result<Att, AttParseError> {
-    let opcode = packet.payload.to_slice()[0];
-    let payload = &packet.payload.to_slice()[1..];
+    let opcode = packet.payload.as_slice()[0];
+    let payload = &packet.payload.as_slice()[1..];
 
     match opcode {
         ATT_READ_BY_GROUP_TYPE_REQUEST_OPCODE => {
@@ -202,7 +207,7 @@ pub fn parse_att(packet: L2capPacket) -> Result<Att, AttParseError> {
             Ok(Att::ReadByGroupTypeReq {
                 start: start_handle,
                 end: end_handle,
-                group_type: group_type,
+                group_type,
             })
         }
         ATT_READ_BY_TYPE_REQUEST_OPCODE => {
@@ -287,180 +292,138 @@ pub fn parse_att(packet: L2capPacket) -> Result<Att, AttParseError> {
     }
 }
 
-#[derive(Debug)]
-pub struct AttributeData {
-    attribute_handle: u16,
-    end_group_handle: u16,
-    attribute_value: Uuid,
-}
-
-impl AttributeData {
-    pub fn new(
+impl Data {
+    pub fn append_attribute_data(
+        &mut self,
         attribute_handle: u16,
         end_group_handle: u16,
-        attribute_value: Uuid,
-    ) -> AttributeData {
-        AttributeData {
-            attribute_handle,
-            end_group_handle,
-            attribute_value,
+        attribute_value: &Uuid,
+    ) {
+        self.append_value(attribute_handle);
+        self.append_value(end_group_handle);
+        self.append_uuid(attribute_value);
+    }
+
+    pub fn new_att_read_by_group_type_response() -> Self {
+        Self::new(&[
+            ATT_READ_BY_GROUP_TYPE_RESPONSE_OPCODE,
+            0u8, /* size to modify/check later */
+        ])
+    }
+
+    pub fn append_att_read_by_group_type_response(
+        &mut self,
+        attribute_handle: u16,
+        end_group_handle: u16,
+        attribute_value: &Uuid,
+    ) {
+        let len = attribute_value.len() as u8;
+        if self.data[1] == 0 {
+            self.data[1] = len;
+        } else if self.data[1] != len {
+            panic!("Non-uniform UUIDs");
         }
+        self.append_attribute_data(attribute_handle, end_group_handle, attribute_value);
     }
 
-    pub fn encode(&self) -> Data {
-        let mut data = Data::default();
-        data.append(&[
-            (self.attribute_handle & 0xff) as u8,
-            ((self.attribute_handle >> 8) & 0xff) as u8,
-        ]);
-        data.append(&[
-            (self.end_group_handle & 0xff) as u8,
-            ((self.end_group_handle >> 8) & 0xff) as u8,
-        ]);
-        data.append(self.attribute_value.encode().to_slice());
-        data
-    }
-}
-
-#[derive(Debug)]
-pub struct AttributePayloadData {
-    attribute_handle: u16,
-    attribute_value: Data,
-}
-
-impl AttributePayloadData {
-    pub fn new(attribute_handle: u16, attribute_value: Data) -> AttributePayloadData {
-        AttributePayloadData {
-            attribute_handle,
-            attribute_value,
-        }
-    }
-
-    pub fn encode(&self) -> Data {
-        let mut data = Data::default();
-        data.append(&[
-            (self.attribute_handle & 0xff) as u8,
-            ((self.attribute_handle >> 8) & 0xff) as u8,
-        ]);
-        data.append(self.attribute_value.to_slice());
+    pub fn new_att_error_response(opcode: u8, handle: u16, code: AttErrorCode) -> Self {
+        let mut data = Self::new(&[ATT_ERROR_RESPONSE_OPCODE, opcode]);
+        data.append_value(handle);
+        data.append_value(code as u8);
         data
     }
 
-    pub fn len(&self) -> usize {
-        2 + self.attribute_value.len()
-    }
-}
-
-pub fn att_encode_read_by_group_type_response(attribute_list: &[AttributeData]) -> Data {
-    let attribute_data_size = match attribute_list[0].attribute_value {
-        Uuid::Uuid16(_) => 6,
-        Uuid::Uuid128(_) => 20,
-    };
-
-    let mut data = Data::default();
-    data.append(&[ATT_READ_BY_GROUP_TYPE_RESPONSE_OPCODE]);
-    data.append(&[attribute_data_size]);
-
-    for att_data in attribute_list {
-        data.append(att_data.encode().to_slice());
+    pub fn new_att_read_by_type_response() -> Self {
+        Self::new(&[
+            ATT_READ_BY_TYPE_RESPONSE_OPCODE,
+            0u8, /* size to set/check later */
+        ])
     }
 
-    data
-}
-
-pub fn att_encode_error_response(opcode: u8, handle: u16, code: AttErrorCode) -> Data {
-    let mut data = Data::default();
-    data.append(&[ATT_ERROR_RESPONSE_OPCODE]);
-    data.append(&[opcode]);
-    data.append(&[(handle & 0xff) as u8, ((handle >> 8) & 0xff) as u8]);
-    data.append(&[code as u8]);
-
-    data
-}
-
-pub fn att_encode_read_by_type_response(attribute_list: &[AttributePayloadData]) -> Data {
-    let attribute_data_size = attribute_list[0].len(); // check if empty
-
-    let mut data = Data::default();
-    data.append(&[ATT_READ_BY_TYPE_RESPONSE_OPCODE]);
-    data.append(&[attribute_data_size as u8]);
-
-    for att_data in attribute_list {
-        data.append(att_data.encode().to_slice());
+    pub fn append_att_read_by_type_response(&mut self) {
+        let size = self.len() - 2;
+        // check if empty
+        if size == 0 {
+            panic!("Missing attribute payloads");
+        }
+        if self.data[1] == 0 {
+            /* set size */
+            self.data[1] = size as u8;
+        } else {
+            if size % self.data[1] as usize > 0 {
+                panic!("Non-uniform attribute payloads");
+            }
+        }
     }
 
-    data
-}
-
-impl Data {
-    pub fn new_read_response() -> Data {
-        Data::new(&[ATT_READ_RESPONSE_OPCODE])
-    }
-}
-
-pub fn att_encode_write_response() -> Data {
-    let mut data = Data::default();
-    data.append(&[ATT_WRITE_RESPONSE_OPCODE]);
-
-    data
-}
-
-pub fn att_encode_exchange_mtu_response(mtu: u16) -> Data {
-    let mut data = Data::default();
-    data.append(&[ATT_EXCHANGE_MTU_RESPONSE_OPCODE]);
-    data.append(&[(mtu & 0xff) as u8, ((mtu >> 8) & 0xff) as u8]);
-
-    data
-}
-
-pub fn att_encode_find_information_response(uuid_type: u8, list: &[Option<(u16, Uuid)>]) -> Data {
-    let mut data = Data::default();
-
-    data.append(&[ATT_FIND_INFORMATION_RSP_OPCODE]);
-    data.append(&[uuid_type]);
-
-    for element in list {
-        let (handle, uuid) = element.unwrap();
-        data.append(&handle.to_le_bytes());
-        let uuid_bytes = uuid.encode();
-        data.append(uuid_bytes.to_slice());
+    pub fn new_att_read_response() -> Self {
+        Self::new(&[ATT_READ_RESPONSE_OPCODE])
     }
 
-    data
-}
+    pub fn has_att_read_response_data(&self) -> bool {
+        self.len() > 1
+    }
 
-pub fn att_encode_prepare_write_response(handle: u16, offset: u16, payload: &[u8]) -> Data {
-    let mut data = Data::default();
+    pub fn new_att_write_response() -> Self {
+        Self::new(&[ATT_WRITE_RESPONSE_OPCODE])
+    }
 
-    data.append(&[ATT_PREPARE_WRITE_RESP_OPCODE]);
-    data.append(&handle.to_le_bytes());
-    data.append(&offset.to_le_bytes());
-    data.append(payload);
+    pub fn new_att_exchange_mtu_response(mtu: u16) -> Self {
+        let mut data = Self::new(&[ATT_EXCHANGE_MTU_RESPONSE_OPCODE]);
+        data.append_value(mtu);
+        data
+    }
 
-    data
-}
+    pub fn new_att_find_information_response() -> Self {
+        Self::new(&[
+            ATT_FIND_INFORMATION_RSP_OPCODE,
+            0u8, /* uuid_type to set/check later */
+        ])
+    }
 
-pub fn att_encode_execute_write_response() -> Data {
-    let mut data = Data::default();
+    pub fn append_att_find_information_response(&mut self, handle: u16, uuid: &Uuid) -> bool {
+        if self.data[1] == 0 {
+            self.data[1] = uuid.get_type();
+        } else if self.data[1] != uuid.get_type() {
+            return false;
+        }
 
-    data.append(&[ATT_EXECUTE_WRITE_RESP_OPCODE]);
+        self.append_value(handle);
+        self.append_uuid(&uuid);
 
-    data
-}
+        true
+    }
 
-pub fn att_encode_read_blob_response(payload: Data) -> Data {
-    let mut data = Data::default();
-    data.append(&[ATT_READ_BLOB_RESP_OPCODE]);
-    data.append(payload.to_slice());
+    pub fn has_att_find_information_response_data(&self) -> bool {
+        self.len() > 2
+    }
 
-    data
-}
+    pub fn new_att_prepare_write_response(handle: u16, offset: u16) -> Self {
+        let mut data = Self::new(&[ATT_PREPARE_WRITE_RESP_OPCODE]);
+        data.append_value(handle);
+        data.append_value(offset);
+        data
+    }
 
-pub fn att_encode_value_ntf(handle: u16, payload: &[u8]) -> Data {
-    let mut data = Data::default();
-    data.append(&[ATT_HANDLE_VALUE_NTF_OPTCODE]);
-    data.append(&handle.to_le_bytes());
-    data.append(payload);
+    pub fn has_att_prepare_write_response_data(&self) -> bool {
+        self.len() > 5
+    }
 
-    data
+    pub fn new_att_execute_write_response() -> Self {
+        Self::new(&[ATT_EXECUTE_WRITE_RESP_OPCODE])
+    }
+
+    pub fn new_att_read_blob_response() -> Self {
+        Self::new(&[ATT_READ_BLOB_RESP_OPCODE])
+    }
+
+    pub fn has_att_read_blob_response_data(&self) -> bool {
+        self.len() > 1
+    }
+
+    pub fn new_att_value_ntf(handle: u16) -> Self {
+        let mut data = Self::new(&[ATT_HANDLE_VALUE_NTF_OPTCODE]);
+        data.append_value(handle);
+        data
+    }
 }

--- a/bleps/src/att.rs
+++ b/bleps/src/att.rs
@@ -323,13 +323,13 @@ impl AttributeData {
 }
 
 #[derive(Debug)]
-pub struct AttributePayloadData<'a> {
+pub struct AttributePayloadData {
     attribute_handle: u16,
-    attribute_value: &'a [u8],
+    attribute_value: Data,
 }
 
-impl<'a> AttributePayloadData<'a> {
-    pub fn new(attribute_handle: u16, attribute_value: &'a [u8]) -> AttributePayloadData<'a> {
+impl AttributePayloadData {
+    pub fn new(attribute_handle: u16, attribute_value: Data) -> AttributePayloadData {
         AttributePayloadData {
             attribute_handle,
             attribute_value,
@@ -342,7 +342,7 @@ impl<'a> AttributePayloadData<'a> {
             (self.attribute_handle & 0xff) as u8,
             ((self.attribute_handle >> 8) & 0xff) as u8,
         ]);
-        data.append(self.attribute_value);
+        data.append(self.attribute_value.to_slice());
         data
     }
 
@@ -392,12 +392,10 @@ pub fn att_encode_read_by_type_response(attribute_list: &[AttributePayloadData])
     data
 }
 
-pub fn att_encode_read_response(payload: &[u8]) -> Data {
-    let mut data = Data::default();
-    data.append(&[ATT_READ_RESPONSE_OPCODE]);
-    data.append(payload);
-
-    data
+impl Data {
+    pub fn new_read_response() -> Data {
+        Data::new(&[ATT_READ_RESPONSE_OPCODE])
+    }
 }
 
 pub fn att_encode_write_response() -> Data {
@@ -450,10 +448,10 @@ pub fn att_encode_execute_write_response() -> Data {
     data
 }
 
-pub fn att_encode_read_blob_response(payload: &[u8]) -> Data {
+pub fn att_encode_read_blob_response(payload: Data) -> Data {
     let mut data = Data::default();
     data.append(&[ATT_READ_BLOB_RESP_OPCODE]);
-    data.append(payload);
+    data.append(payload.to_slice());
 
     data
 }

--- a/bleps/src/attribute.rs
+++ b/bleps/src/attribute.rs
@@ -1,0 +1,260 @@
+use core::{fmt, mem::size_of, slice};
+
+use crate::{att::Uuid, Data};
+
+pub trait AttData {
+    fn readable(&self) -> bool {
+        false
+    }
+
+    fn read(&mut self, _offset: usize, _data: &mut [u8]) -> usize {
+        0
+    }
+
+    fn writable(&self) -> bool {
+        false
+    }
+
+    fn write(&mut self, _offset: usize, _data: &[u8]) {}
+}
+
+impl<'a, const N: usize> AttData for &'a [u8; N] {
+    fn readable(&self) -> bool {
+        true
+    }
+
+    fn read(&mut self, offset: usize, data: &mut [u8]) -> usize {
+        if offset > N {
+            return 0;
+        }
+        let len = data.len().min(N - offset);
+        if len > 0 {
+            data[..len].copy_from_slice(&self[offset..offset + len]);
+        }
+        len
+    }
+}
+
+impl<'a, const N: usize> AttData for &'a mut [u8; N] {
+    fn readable(&self) -> bool {
+        true
+    }
+
+    fn read(&mut self, offset: usize, data: &mut [u8]) -> usize {
+        if offset > N {
+            return 0;
+        }
+        let len = data.len().min(N - offset);
+        if len > 0 {
+            data[..len].copy_from_slice(&self[offset..offset + len]);
+        }
+        len
+    }
+
+    fn writable(&self) -> bool {
+        true
+    }
+
+    fn write(&mut self, offset: usize, data: &[u8]) {
+        if offset > N {
+            return;
+        }
+        let len = data.len().min(N - offset);
+        if len > 0 {
+            self[offset..offset + len].copy_from_slice(&data[..len]);
+        }
+    }
+}
+
+impl<'a> AttData for &'a [u8] {
+    fn readable(&self) -> bool {
+        true
+    }
+
+    fn read(&mut self, offset: usize, data: &mut [u8]) -> usize {
+        let len = self.len();
+        if offset > len {
+            return 0;
+        }
+        let len = data.len().min(len - offset);
+        data[..len].copy_from_slice(&self[offset..offset + len]);
+        len
+    }
+}
+
+impl<'a> AttData for &'a mut [u8] {
+    fn readable(&self) -> bool {
+        true
+    }
+
+    fn read(&mut self, offset: usize, data: &mut [u8]) -> usize {
+        let len = self.len();
+        if offset > len {
+            return 0;
+        }
+        let len = data.len().min(len - offset);
+        data[..len].copy_from_slice(&self[offset..offset + len]);
+        len
+    }
+
+    fn writable(&self) -> bool {
+        true
+    }
+
+    fn write(&mut self, offset: usize, data: &[u8]) {
+        let len = self.len();
+        if offset > len {
+            return;
+        }
+        let len = data.len().min(len - offset);
+        self[offset..offset + len].copy_from_slice(&data[..len]);
+    }
+}
+
+impl<'a, T: Sized + 'static> AttData for &'a (T,) {
+    fn readable(&self) -> bool {
+        true
+    }
+
+    fn read(&mut self, offset: usize, data: &mut [u8]) -> usize {
+        if offset > size_of::<T>() {
+            return 0;
+        }
+        let len = data.len().min(size_of::<T>() - offset);
+        if len > 0 {
+            let slice =
+                unsafe { slice::from_raw_parts(&self.0 as *const T as *const u8, size_of::<T>()) };
+            // TODO: Handle big endian case
+            data[..len].copy_from_slice(&slice[offset..offset + len]);
+        }
+        len
+    }
+}
+
+impl<'a, T: Sized + 'static> AttData for &'a mut (T,) {
+    fn readable(&self) -> bool {
+        true
+    }
+
+    fn read(&mut self, offset: usize, data: &mut [u8]) -> usize {
+        if offset > size_of::<T>() {
+            return 0;
+        }
+        let len = data.len().min(size_of::<T>() - offset);
+        if len > 0 {
+            let slice =
+                unsafe { slice::from_raw_parts(&self.0 as *const T as *const u8, size_of::<T>()) };
+            // TODO: Handle big endian case
+            data[..len].copy_from_slice(&slice[offset..offset + len]);
+        }
+        len
+    }
+
+    fn writable(&self) -> bool {
+        true
+    }
+
+    fn write(&mut self, offset: usize, data: &[u8]) {
+        if offset > size_of::<T>() {
+            return;
+        }
+        let len = data.len().min(size_of::<T>() - offset);
+        if len > 0 {
+            let slice = unsafe {
+                slice::from_raw_parts_mut(&mut self.0 as *mut T as *mut u8, size_of::<T>())
+            };
+            // TODO: Handle big endian case
+            slice[offset..offset + len].copy_from_slice(&data[..len]);
+        }
+    }
+}
+
+impl<R> AttData for (R, ())
+where
+    R: FnMut(usize, &mut [u8]) -> usize,
+{
+    fn readable(&self) -> bool {
+        true
+    }
+
+    fn read(&mut self, offset: usize, data: &mut [u8]) -> usize {
+        self.0(offset, data)
+    }
+}
+
+impl<W> AttData for ((), W)
+where
+    W: FnMut(usize, &[u8]),
+{
+    fn writable(&self) -> bool {
+        true
+    }
+
+    fn write(&mut self, offset: usize, data: &[u8]) {
+        self.1(offset, data);
+    }
+}
+
+impl<R, W> AttData for (R, W)
+where
+    R: FnMut(usize, &mut [u8]) -> usize,
+    W: FnMut(usize, &[u8]),
+{
+    fn readable(&self) -> bool {
+        true
+    }
+
+    fn read(&mut self, offset: usize, data: &mut [u8]) -> usize {
+        self.0(offset, data)
+    }
+
+    fn writable(&self) -> bool {
+        true
+    }
+
+    fn write(&mut self, offset: usize, data: &[u8]) {
+        self.1(offset, data);
+    }
+}
+
+pub const ATT_READABLE: u8 = 0x02;
+pub const ATT_WRITEABLE: u8 = 0x08;
+
+pub struct Attribute<'a> {
+    pub uuid: Uuid,
+    pub handle: u16,
+    pub data: &'a mut dyn AttData,
+    pub last_handle_in_group: u16,
+}
+
+impl<'a> fmt::Debug for Attribute<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Attribute")
+            .field("uuid", &self.uuid)
+            .field("handle", &self.handle)
+            .field("last_handle_in_group", &self.last_handle_in_group)
+            .field("readable", &self.data.readable())
+            .field("writable", &self.data.writable())
+            .finish()
+    }
+}
+
+impl<'a> Attribute<'a> {
+    pub fn new(uuid: Uuid, data: &'a mut impl AttData) -> Attribute<'a> {
+        Attribute {
+            uuid,
+            handle: 0,
+            data,
+            last_handle_in_group: 0,
+        }
+    }
+
+    pub(crate) fn value(&mut self) -> Data {
+        let mut data = Data::default();
+        if self.data.readable() {
+            let len = self.data.read(0, data.as_slice_mut());
+            data.append_len(len);
+        }
+        data
+    }
+}

--- a/bleps/src/attribute_server.rs
+++ b/bleps/src/attribute_server.rs
@@ -93,7 +93,7 @@ impl<'a> AttributeServer<'a> {
                 ..
             } => {
                 if let Some(rf) = read_function {
-                    Some((&mut *rf)(offset, buffer))
+                    Some((&mut *rf)(offset as usize, buffer))
                 } else {
                     None
                 }
@@ -467,7 +467,7 @@ impl<'a> AttributeServer<'a> {
                         ..
                     } => {
                         if let Some(wf) = write_function {
-                            (&mut *wf)(offset, value.as_slice());
+                            (&mut *wf)(offset as usize, value.as_slice());
                         }
                     }
                 };
@@ -510,7 +510,7 @@ impl<'a> AttributeServer<'a> {
                         ..
                     } => {
                         if let Some(rf) = read_function {
-                            let len = (&mut *rf)(offset, data.as_slice_mut());
+                            let len = (&mut *rf)(offset as usize, data.as_slice_mut());
                             data.append_len(len);
                         }
                     }
@@ -560,8 +560,8 @@ pub const ATT_WRITEABLE: u8 = 0x08;
 pub enum AttData<'a> {
     Static(&'a [u8]),
     Dynamic {
-        read_function: Option<&'a mut dyn FnMut(u16, &mut [u8]) -> usize>,
-        write_function: Option<&'a mut dyn FnMut(u16, &[u8])>,
+        read_function: Option<&'a mut dyn FnMut(usize, &mut [u8]) -> usize>,
+        write_function: Option<&'a mut dyn FnMut(usize, &[u8])>,
     },
 }
 

--- a/bleps/src/command.rs
+++ b/bleps/src/command.rs
@@ -90,7 +90,7 @@ pub fn create_command_data(command: Command) -> Data {
             adv_params.append(&[params.advertising_channel_map]);
             adv_params.append(&[params.filter_policy as u8]);
 
-            data[4..].copy_from_slice(adv_params.to_slice());
+            data[4..].copy_from_slice(adv_params.as_slice());
             Data::new(&data)
         }
         Command::LeSetAdvertisingData { ref data } => {
@@ -99,7 +99,7 @@ pub fn create_command_data(command: Command) -> Data {
             CommandHeader::from_ogf_ocf(LE_OGF, SET_ADVERTISING_DATA_OCF, data.len as u8)
                 .write_into(&mut header[1..]);
             let mut res = Data::new(&header);
-            res.append(data.to_slice());
+            res.append(data.as_slice());
             res
         }
         Command::LeSetAdvertiseEnable(enable) => {

--- a/bleps/src/event.rs
+++ b/bleps/src/event.rs
@@ -79,7 +79,7 @@ pub fn parse_event(connector: &dyn HciConnection) -> EventType {
 
     match event.code {
         EVENT_COMMAND_COMPLETE => {
-            let data = event.data.to_slice();
+            let data = event.data.as_slice();
             let num_packets = data[0];
             let opcode = ((data[2] as u16) << 8) + data[1] as u16;
             let data = event.data.subdata_from(3);
@@ -90,7 +90,7 @@ pub fn parse_event(connector: &dyn HciConnection) -> EventType {
             }
         }
         EVENT_DISCONNECTION_COMPLETE => {
-            let data = event.data.to_slice();
+            let data = event.data.as_slice();
             let status = data[0];
             let handle = ((data[2] as u16) << 8) + data[1] as u16;
             let reason = data[3];
@@ -103,7 +103,7 @@ pub fn parse_event(connector: &dyn HciConnection) -> EventType {
             }
         }
         EVENT_NUMBER_OF_COMPLETED_PACKETS => {
-            let data = event.data.to_slice();
+            let data = event.data.as_slice();
             let num_handles = data[0];
             let connection_handle = ((data[2] as u16) << 8) + data[1] as u16;
             let completed_packet = ((data[4] as u16) << 8) + data[3] as u16;
@@ -117,7 +117,7 @@ pub fn parse_event(connector: &dyn HciConnection) -> EventType {
             info!(
                 "Ignoring unknown event {:02x} data = {:02x?}",
                 event.code,
-                event.data.to_slice()
+                event.data.as_slice()
             );
             EventType::Unknown
         }
@@ -141,7 +141,7 @@ where
 
     match event.code {
         EVENT_COMMAND_COMPLETE => {
-            let data = event.data.to_slice();
+            let data = event.data.as_slice();
             let num_packets = data[0];
             let opcode = ((data[2] as u16) << 8) + data[1] as u16;
             let data = event.data.subdata_from(3);
@@ -152,7 +152,7 @@ where
             }
         }
         EVENT_DISCONNECTION_COMPLETE => {
-            let data = event.data.to_slice();
+            let data = event.data.as_slice();
             let status = data[0];
             let handle = ((data[2] as u16) << 8) + data[1] as u16;
             let reason = data[3];
@@ -165,7 +165,7 @@ where
             }
         }
         EVENT_NUMBER_OF_COMPLETED_PACKETS => {
-            let data = event.data.to_slice();
+            let data = event.data.as_slice();
             let num_handles = data[0];
             let connection_handle = ((data[2] as u16) << 8) + data[1] as u16;
             let completed_packet = ((data[4] as u16) << 8) + data[3] as u16;
@@ -179,7 +179,7 @@ where
             info!(
                 "Ignoring unknown event {:02x} data = {:02x?}",
                 event.code,
-                event.data.to_slice()
+                event.data.as_slice()
             );
             EventType::Unknown
         }

--- a/bleps/src/event.rs
+++ b/bleps/src/event.rs
@@ -1,5 +1,3 @@
-use log::info;
-
 use crate::{read_to_data, Data, HciConnection};
 
 #[derive(Debug)]
@@ -114,7 +112,7 @@ pub fn parse_event(connector: &dyn HciConnection) -> EventType {
             }
         }
         _ => {
-            info!(
+            log::warn!(
                 "Ignoring unknown event {:02x} data = {:02x?}",
                 event.code,
                 event.data.as_slice()
@@ -176,7 +174,7 @@ where
             }
         }
         _ => {
-            info!(
+            log::warn!(
                 "Ignoring unknown event {:02x} data = {:02x?}",
                 event.code,
                 event.data.as_slice()

--- a/bleps/src/l2cap.rs
+++ b/bleps/src/l2cap.rs
@@ -13,7 +13,7 @@ pub enum L2capParseError {
 }
 
 pub fn parse_l2cap(packet: AclPacket) -> Result<(u16, L2capPacket), L2capParseError> {
-    let data = packet.data.to_slice();
+    let data = packet.data.as_slice();
     let length = (data[0] as u16) + ((data[1] as u16) << 8);
     let channel = (data[2] as u16) + ((data[3] as u16) << 8);
     let payload = Data::new(&data[4..]);
@@ -32,7 +32,7 @@ pub fn encode_l2cap(att_data: Data) -> Data {
     let mut data = Data::default();
     data.append(&[0, 0]); // len set later
     data.append(&[0x04, 0x00]); // channel
-    data.append(att_data.to_slice());
+    data.append(att_data.as_slice());
 
     let len = data.len - 4;
     data.set(0, (len & 0xff) as u8);

--- a/bleps/src/lib.rs
+++ b/bleps/src/lib.rs
@@ -22,6 +22,7 @@ pub mod event;
 
 pub mod ad_structure;
 
+pub mod attribute;
 pub mod attribute_server;
 
 #[cfg(feature = "async")]

--- a/bleps/src/lib.rs
+++ b/bleps/src/lib.rs
@@ -67,6 +67,28 @@ impl Data {
         &self.data[0..self.len]
     }
 
+    pub fn as_slice_mut(&mut self) -> &mut [u8] {
+        &mut self.data[self.len..]
+    }
+
+    pub fn set_len(&mut self, new_len: usize) {
+        self.len = if new_len > self.data.len() {
+            self.data.len()
+        } else {
+            new_len
+        };
+    }
+
+    pub fn append_len(&mut self, extra_len: usize) {
+        self.set_len(self.len + extra_len);
+    }
+
+    pub fn limit_len(&mut self, max_len: usize) {
+        if self.len > max_len {
+            self.len = max_len;
+        }
+    }
+
     pub fn subdata_from(&self, from: usize) -> Data {
         let mut data = [0u8; 128];
         let new_len = self.len - from;

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -5,7 +5,8 @@ edition = "2021"
 
 [dependencies]
 serialport = "4.2.0"
-embedded-io = { version = "0.3.1", features = ["std"] }
+critical-section = "1.1.1"
+embedded-io = { version = "0.4.0", features = ["std"] }
 bleps = { path = "../bleps", features = ["macros"] }
 env_logger = "0.10.0"
 crossterm = "0.25.0"

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -80,7 +80,7 @@ fn main() {
 
         let mut rf = {
             let val = val.clone();
-            move |offset: u16, data: &mut [u8]| {
+            move |offset: usize, data: &mut [u8]| {
                 let val = val.lock().unwrap();
                 let off = offset as usize;
                 if off < val.len() {
@@ -95,7 +95,7 @@ fn main() {
         };
         let mut wf = {
             let val = val.clone();
-            move |offset: u16, data: &[u8]| {
+            move |offset: usize, data: &[u8]| {
                 println!("RECEIVED: Offset {}, data {:x?}", offset, data);
                 let mut val = val.lock().unwrap();
                 let off = offset as usize;
@@ -110,15 +110,15 @@ fn main() {
             }
         };
 
-        let mut wf2 = |offset: u16, data: &[u8]| {
+        let mut wf2 = |offset: usize, data: &[u8]| {
             println!("RECEIVED2: Offset {}, data {:x?}", offset, data);
         };
 
-        let mut rf3 = |offset: u16, data: &mut [u8]| {
+        let mut rf3 = |_offset: usize, data: &mut [u8]| {
             data[..5].copy_from_slice(&b"Hola!"[..]);
             5
         };
-        let mut wf3 = |offset: u16, data: &[u8]| {
+        let mut wf3 = |offset: usize, data: &[u8]| {
             println!("RECEIVED3: Offset {}, data {:x?}", offset, data);
         };
 


### PR DESCRIPTION
I propose refusing AttData enum in favor of AttData trait.
The trait-based solution is quite useful for users which needs own way to access attribute data.
I implemented such trait for byte slices and arrays, static sized values, and tuples of functions.
Also I made many fixes to avoid unnecessary data copying when creating responses.