### PR TITLE
Code refactoring and cleanup

### DIFF
--- a/bleps/src/acl.rs
+++ b/bleps/src/acl.rs
@@ -1,4 +1,4 @@
-use crate::{read_to_data, Data, HciConnection};
+use crate::{Data, HciConnection};
 
 #[derive(Debug, Clone, Copy)]
 pub struct AclPacket {
@@ -34,115 +34,99 @@ pub enum HostBroadcastFlag {
     Reserved,
 }
 
-pub fn parse_acl_packet(connector: &dyn HciConnection) -> AclPacket {
-    let raw_handle = connector.read().unwrap() as u16 + ((connector.read().unwrap() as u16) << 8);
+impl AclPacket {
+    pub fn read(connector: &dyn HciConnection) -> Self {
+        let raw_handle_buffer = [connector.read().unwrap(), connector.read().unwrap()];
+        let (pb, bc, handle) = Self::parse_raw_handle(raw_handle_buffer);
 
-    let pb = (raw_handle & 0b0011000000000000) >> 12;
-    let pb = match pb {
-        0b00 => BoundaryFlag::FirstNonAutoFlushable,
-        0b01 => BoundaryFlag::Continuing,
-        0b10 => BoundaryFlag::FirstAutoFlushable,
-        0b11 => BoundaryFlag::Complete,
-        _ => panic!("Unexpected boundary flag"),
-    };
+        let len = u16::from_le_bytes([connector.read().unwrap(), connector.read().unwrap()]);
+        let data = Data::read(connector, len as usize);
 
-    let bc = (raw_handle & 0b1100000000000000) >> 14;
-    let bc = match bc {
-        0b00 => ControllerBroadcastFlag::PointToPoint,
-        0b01 => ControllerBroadcastFlag::NotParkedState,
-        0b10 => ControllerBroadcastFlag::ParkedState,
-        0b11 => ControllerBroadcastFlag::Reserved,
-        _ => panic!("Unexpected broadcast flag"),
-    };
-
-    let handle = raw_handle & 0b111111111111;
-
-    let len = connector.read().unwrap() as u16 + ((connector.read().unwrap() as u16) << 8);
-    let data = read_to_data(connector, len as usize);
-
-    AclPacket {
-        handle,
-        boundary_flag: pb,
-        bc_flag: bc,
-        data,
+        Self {
+            handle,
+            boundary_flag: pb,
+            bc_flag: bc,
+            data,
+        }
     }
-}
 
-#[cfg(feature = "async")]
-pub async fn async_parse_acl_packet<T>(connector: &mut T) -> AclPacket
-where
-    T: embedded_io::asynch::Read,
-{
-    let mut raw_handle_buffer = [0u8; 2];
-    let _raw_handle_len = connector.read(&mut raw_handle_buffer).await.unwrap();
-    let raw_handle = raw_handle_buffer[0] as u16 + ((raw_handle_buffer[1] as u16) << 8);
+    #[cfg(feature = "async")]
+    pub async fn async_read<T>(connector: &mut T) -> Self
+    where
+        T: embedded_io::asynch::Read,
+    {
+        let mut raw_handle_buffer = [0u8; 2];
+        let _raw_handle_len = connector.read(&mut raw_handle_buffer).await.unwrap();
+        let (pb, bc, handle) = Self::parse_raw_handle(raw_handle_buffer);
 
-    let pb = (raw_handle & 0b0011000000000000) >> 12;
-    let pb = match pb {
-        0b00 => BoundaryFlag::FirstNonAutoFlushable,
-        0b01 => BoundaryFlag::Continuing,
-        0b10 => BoundaryFlag::FirstAutoFlushable,
-        0b11 => BoundaryFlag::Complete,
-        _ => panic!("Unexpected boundary flag"),
-    };
+        let mut len_buffer = [0u8; 2];
+        let _len_len = connector.read(&mut len_buffer).await.unwrap();
+        let len = u16::from_le_bytes(len_buffer);
+        let data = Data::async_read(connector, len as usize).await;
 
-    let bc = (raw_handle & 0b1100000000000000) >> 14;
-    let bc = match bc {
-        0b00 => ControllerBroadcastFlag::PointToPoint,
-        0b01 => ControllerBroadcastFlag::NotParkedState,
-        0b10 => ControllerBroadcastFlag::ParkedState,
-        0b11 => ControllerBroadcastFlag::Reserved,
-        _ => panic!("Unexpected broadcast flag"),
-    };
-
-    let handle = raw_handle & 0b111111111111;
-
-    let mut len_buffer = [0u8; 2];
-    let _len_len = connector.read(&mut len_buffer).await.unwrap();
-    let len = len_buffer[0] as u16 + ((len_buffer[1] as u16) << 8);
-    let data = crate::asynch::read_to_data(connector, len as usize).await;
-
-    AclPacket {
-        handle,
-        boundary_flag: pb,
-        bc_flag: bc,
-        data,
+        Self {
+            handle,
+            boundary_flag: pb,
+            bc_flag: bc,
+            data,
+        }
     }
-}
 
-// including type (0x02)
-pub fn encode_acl_packet(
-    handle: u16,
-    pb: BoundaryFlag,
-    bc: HostBroadcastFlag,
-    payload: Data,
-) -> Data {
-    let mut data = Data::default();
+    fn parse_raw_handle(
+        raw_handle_buffer: [u8; 2],
+    ) -> (BoundaryFlag, ControllerBroadcastFlag, u16) {
+        let raw_handle = u16::from_le_bytes(raw_handle_buffer);
 
-    data.append(&[0x02]);
+        let pb = (raw_handle & 0b0011000000000000) >> 12;
+        let pb = match pb {
+            0b00 => BoundaryFlag::FirstNonAutoFlushable,
+            0b01 => BoundaryFlag::Continuing,
+            0b10 => BoundaryFlag::FirstAutoFlushable,
+            0b11 => BoundaryFlag::Complete,
+            _ => panic!("Unexpected boundary flag"),
+        };
 
-    let mut raw_handle = handle;
+        let bc = (raw_handle & 0b1100000000000000) >> 14;
+        let bc = match bc {
+            0b00 => ControllerBroadcastFlag::PointToPoint,
+            0b01 => ControllerBroadcastFlag::NotParkedState,
+            0b10 => ControllerBroadcastFlag::ParkedState,
+            0b11 => ControllerBroadcastFlag::Reserved,
+            _ => panic!("Unexpected broadcast flag"),
+        };
 
-    raw_handle |= match pb {
-        BoundaryFlag::FirstNonAutoFlushable => 0b00,
-        BoundaryFlag::Continuing => 0b01,
-        BoundaryFlag::FirstAutoFlushable => 0b10,
-        BoundaryFlag::Complete => 0b11,
-    } << 12;
+        let handle = raw_handle & 0b111111111111;
 
-    raw_handle |= match bc {
-        HostBroadcastFlag::NoBroadcast => 0b00,
-        HostBroadcastFlag::ActiveSlaveBroadcast => 0b01,
-        HostBroadcastFlag::ParkedSlaveBroadcast => 0b10,
-        HostBroadcastFlag::Reserved => 0b11,
-    } << 14;
+        (pb, bc, handle)
+    }
 
-    data.append(&[(raw_handle & 0xff) as u8, ((raw_handle >> 8) & 0xff) as u8]);
+    // including type (0x02)
+    pub fn encode(handle: u16, pb: BoundaryFlag, bc: HostBroadcastFlag, payload: Data) -> Data {
+        let mut data = Data::new(&[0x02]);
 
-    let len = payload.len;
-    data.append(&[(len & 0xff) as u8, ((len >> 8) & 0xff) as u8]);
+        let mut raw_handle = handle;
 
-    data.append(payload.as_slice());
+        raw_handle |= match pb {
+            BoundaryFlag::FirstNonAutoFlushable => 0b00,
+            BoundaryFlag::Continuing => 0b01,
+            BoundaryFlag::FirstAutoFlushable => 0b10,
+            BoundaryFlag::Complete => 0b11,
+        } << 12;
 
-    data
+        raw_handle |= match bc {
+            HostBroadcastFlag::NoBroadcast => 0b00,
+            HostBroadcastFlag::ActiveSlaveBroadcast => 0b01,
+            HostBroadcastFlag::ParkedSlaveBroadcast => 0b10,
+            HostBroadcastFlag::Reserved => 0b11,
+        } << 14;
+
+        data.append(&[(raw_handle & 0xff) as u8, ((raw_handle >> 8) & 0xff) as u8]);
+
+        let len = payload.len;
+        data.append(&[(len & 0xff) as u8, ((len >> 8) & 0xff) as u8]);
+
+        data.append(payload.as_slice());
+
+        data
+    }
 }

--- a/bleps/src/acl.rs
+++ b/bleps/src/acl.rs
@@ -37,7 +37,7 @@ pub enum HostBroadcastFlag {
 impl AclPacket {
     pub fn read(connector: &dyn HciConnection) -> Self {
         let raw_handle_buffer = [connector.read().unwrap(), connector.read().unwrap()];
-        let (pb, bc, handle) = Self::parse_raw_handle(raw_handle_buffer);
+        let (pb, bc, handle) = Self::decode_raw_handle(raw_handle_buffer);
 
         let len = u16::from_le_bytes([connector.read().unwrap(), connector.read().unwrap()]);
         let data = Data::read(connector, len as usize);
@@ -57,7 +57,7 @@ impl AclPacket {
     {
         let mut raw_handle_buffer = [0u8; 2];
         let _raw_handle_len = connector.read(&mut raw_handle_buffer).await.unwrap();
-        let (pb, bc, handle) = Self::parse_raw_handle(raw_handle_buffer);
+        let (pb, bc, handle) = Self::decode_raw_handle(raw_handle_buffer);
 
         let mut len_buffer = [0u8; 2];
         let _len_len = connector.read(&mut len_buffer).await.unwrap();
@@ -72,7 +72,7 @@ impl AclPacket {
         }
     }
 
-    fn parse_raw_handle(
+    fn decode_raw_handle(
         raw_handle_buffer: [u8; 2],
     ) -> (BoundaryFlag, ControllerBroadcastFlag, u16) {
         let raw_handle = u16::from_le_bytes(raw_handle_buffer);

--- a/bleps/src/async_attribute_server.rs
+++ b/bleps/src/async_attribute_server.rs
@@ -210,8 +210,8 @@ where
                     }
                 }
                 crate::PollResult::AsyncData(packet) => {
-                    let (src_handle, l2cap_packet) = L2capPacket::parse(packet)?;
-                    let packet = Att::parse(l2cap_packet)?;
+                    let (src_handle, l2cap_packet) = L2capPacket::decode(packet)?;
+                    let packet = Att::decode(l2cap_packet)?;
                     log::trace!("att: {:x?}", packet);
                     match packet {
                         Att::ReadByGroupTypeReq {

--- a/bleps/src/att.rs
+++ b/bleps/src/att.rs
@@ -178,14 +178,14 @@ pub enum Att {
 }
 
 #[derive(Debug)]
-pub enum AttParseError {
+pub enum AttDecodeError {
     Other,
     UnknownOpcode(u8, Data),
     UnexpectedPayload,
 }
 
 impl Att {
-    pub fn parse(packet: L2capPacket) -> Result<Self, AttParseError> {
+    pub fn decode(packet: L2capPacket) -> Result<Self, AttDecodeError> {
         let opcode = packet.payload.as_slice()[0];
         let payload = &packet.payload.as_slice()[1..];
 
@@ -199,10 +199,10 @@ impl Att {
                 } else if payload.len() == 20 {
                     let uuid = payload[4..21]
                         .try_into()
-                        .map_err(|_| AttParseError::Other)?;
+                        .map_err(|_| AttDecodeError::Other)?;
                     Uuid::Uuid128(uuid)
                 } else {
-                    return Err(AttParseError::UnexpectedPayload);
+                    return Err(AttDecodeError::UnexpectedPayload);
                 };
 
                 Ok(Self::ReadByGroupTypeReq {
@@ -220,10 +220,10 @@ impl Att {
                 } else if payload.len() == 20 {
                     let uuid = payload[4..21]
                         .try_into()
-                        .map_err(|_| AttParseError::Other)?;
+                        .map_err(|_| AttDecodeError::Other)?;
                     Uuid::Uuid128(uuid)
                 } else {
-                    return Err(AttParseError::UnexpectedPayload);
+                    return Err(AttDecodeError::UnexpectedPayload);
                 };
 
                 Ok(Self::ReadByTypeReq {
@@ -289,7 +289,7 @@ impl Att {
                 let offset = (payload[2] as u16) + ((payload[3] as u16) << 8);
                 Ok(Self::ReadBlobReq { handle, offset })
             }
-            _ => Err(AttParseError::UnknownOpcode(opcode, Data::new(payload))),
+            _ => Err(AttDecodeError::UnknownOpcode(opcode, Data::new(payload))),
         }
     }
 }

--- a/bleps/src/att.rs
+++ b/bleps/src/att.rs
@@ -184,111 +184,113 @@ pub enum AttParseError {
     UnexpectedPayload,
 }
 
-pub fn parse_att(packet: L2capPacket) -> Result<Att, AttParseError> {
-    let opcode = packet.payload.as_slice()[0];
-    let payload = &packet.payload.as_slice()[1..];
+impl Att {
+    pub fn parse(packet: L2capPacket) -> Result<Self, AttParseError> {
+        let opcode = packet.payload.as_slice()[0];
+        let payload = &packet.payload.as_slice()[1..];
 
-    match opcode {
-        ATT_READ_BY_GROUP_TYPE_REQUEST_OPCODE => {
-            let start_handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
-            let end_handle = (payload[2] as u16) + ((payload[3] as u16) << 8);
+        match opcode {
+            ATT_READ_BY_GROUP_TYPE_REQUEST_OPCODE => {
+                let start_handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
+                let end_handle = (payload[2] as u16) + ((payload[3] as u16) << 8);
 
-            let group_type = if payload.len() == 6 {
-                Uuid::Uuid16((payload[4] as u16) + ((payload[5] as u16) << 8))
-            } else if payload.len() == 20 {
-                let uuid = payload[4..21]
-                    .try_into()
-                    .map_err(|_| AttParseError::Other)?;
-                Uuid::Uuid128(uuid)
-            } else {
-                return Err(AttParseError::UnexpectedPayload);
-            };
+                let group_type = if payload.len() == 6 {
+                    Uuid::Uuid16((payload[4] as u16) + ((payload[5] as u16) << 8))
+                } else if payload.len() == 20 {
+                    let uuid = payload[4..21]
+                        .try_into()
+                        .map_err(|_| AttParseError::Other)?;
+                    Uuid::Uuid128(uuid)
+                } else {
+                    return Err(AttParseError::UnexpectedPayload);
+                };
 
-            Ok(Att::ReadByGroupTypeReq {
-                start: start_handle,
-                end: end_handle,
-                group_type,
-            })
-        }
-        ATT_READ_BY_TYPE_REQUEST_OPCODE => {
-            let start_handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
-            let end_handle = (payload[2] as u16) + ((payload[3] as u16) << 8);
+                Ok(Self::ReadByGroupTypeReq {
+                    start: start_handle,
+                    end: end_handle,
+                    group_type,
+                })
+            }
+            ATT_READ_BY_TYPE_REQUEST_OPCODE => {
+                let start_handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
+                let end_handle = (payload[2] as u16) + ((payload[3] as u16) << 8);
 
-            let attribute_type = if payload.len() == 6 {
-                Uuid::Uuid16((payload[4] as u16) + ((payload[5] as u16) << 8))
-            } else if payload.len() == 20 {
-                let uuid = payload[4..21]
-                    .try_into()
-                    .map_err(|_| AttParseError::Other)?;
-                Uuid::Uuid128(uuid)
-            } else {
-                return Err(AttParseError::UnexpectedPayload);
-            };
+                let attribute_type = if payload.len() == 6 {
+                    Uuid::Uuid16((payload[4] as u16) + ((payload[5] as u16) << 8))
+                } else if payload.len() == 20 {
+                    let uuid = payload[4..21]
+                        .try_into()
+                        .map_err(|_| AttParseError::Other)?;
+                    Uuid::Uuid128(uuid)
+                } else {
+                    return Err(AttParseError::UnexpectedPayload);
+                };
 
-            Ok(Att::ReadByTypeReq {
-                start: start_handle,
-                end: end_handle,
-                attribute_type,
-            })
-        }
-        ATT_READ_REQUEST_OPCODE => {
-            let handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
+                Ok(Self::ReadByTypeReq {
+                    start: start_handle,
+                    end: end_handle,
+                    attribute_type,
+                })
+            }
+            ATT_READ_REQUEST_OPCODE => {
+                let handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
 
-            Ok(Att::ReadReq { handle })
-        }
-        ATT_WRITE_REQUEST_OPCODE => {
-            let handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
-            let mut data = Data::default();
-            data.append(&payload[2..]);
+                Ok(Self::ReadReq { handle })
+            }
+            ATT_WRITE_REQUEST_OPCODE => {
+                let handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
+                let mut data = Data::default();
+                data.append(&payload[2..]);
 
-            Ok(Att::WriteReq { handle, data })
-        }
-        ATT_EXCHANGE_MTU_REQUEST_OPCODE => {
-            let mtu = (payload[0] as u16) + ((payload[1] as u16) << 8);
-            Ok(Att::ExchangeMtu { mtu })
-        }
-        ATT_FIND_BY_TYPE_VALUE_REQUEST_OPCODE => {
-            let start_handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
-            let end_handle = (payload[2] as u16) + ((payload[3] as u16) << 8);
-            let att_type = (payload[4] as u16) + ((payload[5] as u16) << 8);
-            let att_value = (payload[6] as u16) + ((payload[7] as u16) << 8); // only U16 supported here
+                Ok(Self::WriteReq { handle, data })
+            }
+            ATT_EXCHANGE_MTU_REQUEST_OPCODE => {
+                let mtu = (payload[0] as u16) + ((payload[1] as u16) << 8);
+                Ok(Self::ExchangeMtu { mtu })
+            }
+            ATT_FIND_BY_TYPE_VALUE_REQUEST_OPCODE => {
+                let start_handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
+                let end_handle = (payload[2] as u16) + ((payload[3] as u16) << 8);
+                let att_type = (payload[4] as u16) + ((payload[5] as u16) << 8);
+                let att_value = (payload[6] as u16) + ((payload[7] as u16) << 8); // only U16 supported here
 
-            Ok(Att::FindByTypeValue {
-                start_handle,
-                end_handle,
-                att_type,
-                att_value,
-            })
-        }
-        ATT_FIND_INFORMATION_REQ_OPCODE => {
-            let start_handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
-            let end_handle = (payload[2] as u16) + ((payload[3] as u16) << 8);
+                Ok(Self::FindByTypeValue {
+                    start_handle,
+                    end_handle,
+                    att_type,
+                    att_value,
+                })
+            }
+            ATT_FIND_INFORMATION_REQ_OPCODE => {
+                let start_handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
+                let end_handle = (payload[2] as u16) + ((payload[3] as u16) << 8);
 
-            Ok(Att::FindInformation {
-                start_handle,
-                end_handle,
-            })
+                Ok(Self::FindInformation {
+                    start_handle,
+                    end_handle,
+                })
+            }
+            ATT_PREPARE_WRITE_REQ_OPCODE => {
+                let handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
+                let offset = (payload[2] as u16) + ((payload[3] as u16) << 8);
+                let value = &payload[4..];
+                Ok(Self::PrepareWriteReq {
+                    handle,
+                    offset,
+                    value: Data::new(value),
+                })
+            }
+            ATT_EXECUTE_WRITE_REQ_OPCODE => {
+                let flags = payload[0];
+                Ok(Self::ExecuteWriteReq { flags })
+            }
+            ATT_READ_BLOB_REQ_OPCODE => {
+                let handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
+                let offset = (payload[2] as u16) + ((payload[3] as u16) << 8);
+                Ok(Self::ReadBlobReq { handle, offset })
+            }
+            _ => Err(AttParseError::UnknownOpcode(opcode, Data::new(payload))),
         }
-        ATT_PREPARE_WRITE_REQ_OPCODE => {
-            let handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
-            let offset = (payload[2] as u16) + ((payload[3] as u16) << 8);
-            let value = &payload[4..];
-            Ok(Att::PrepareWriteReq {
-                handle,
-                offset,
-                value: Data::new(value),
-            })
-        }
-        ATT_EXECUTE_WRITE_REQ_OPCODE => {
-            let flags = payload[0];
-            Ok(Att::ExecuteWriteReq { flags })
-        }
-        ATT_READ_BLOB_REQ_OPCODE => {
-            let handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
-            let offset = (payload[2] as u16) + ((payload[3] as u16) << 8);
-            Ok(Att::ReadBlobReq { handle, offset })
-        }
-        _ => Err(AttParseError::UnknownOpcode(opcode, Data::new(payload))),
     }
 }
 

--- a/bleps/src/attribute_server.rs
+++ b/bleps/src/attribute_server.rs
@@ -1,7 +1,7 @@
 use crate::{
     acl::{AclPacket, BoundaryFlag, HostBroadcastFlag},
     att::{
-        Att, AttErrorCode, AttParseError, Uuid, ATT_FIND_BY_TYPE_VALUE_REQUEST_OPCODE,
+        Att, AttDecodeError, AttErrorCode, Uuid, ATT_FIND_BY_TYPE_VALUE_REQUEST_OPCODE,
         ATT_FIND_INFORMATION_REQ_OPCODE, ATT_PREPARE_WRITE_REQ_OPCODE, ATT_READ_BLOB_REQ_OPCODE,
         ATT_READ_BY_GROUP_TYPE_REQUEST_OPCODE, ATT_READ_BY_TYPE_REQUEST_OPCODE,
         ATT_READ_REQUEST_OPCODE, ATT_WRITE_REQUEST_OPCODE,
@@ -9,7 +9,7 @@ use crate::{
     attribute::Attribute,
     command::{Command, LE_OGF, SET_ADVERTISING_DATA_OCF},
     event::EventType,
-    l2cap::{L2capPacket, L2capParseError},
+    l2cap::{L2capDecodeError, L2capPacket},
     Ble, Data, Error,
 };
 
@@ -27,18 +27,18 @@ pub enum WorkResult {
 
 #[derive(Debug)]
 pub enum AttributeServerError {
-    L2capError(L2capParseError),
-    AttError(AttParseError),
+    L2capError(L2capDecodeError),
+    AttError(AttDecodeError),
 }
 
-impl From<L2capParseError> for AttributeServerError {
-    fn from(err: L2capParseError) -> Self {
+impl From<L2capDecodeError> for AttributeServerError {
+    fn from(err: L2capDecodeError) -> Self {
         AttributeServerError::L2capError(err)
     }
 }
 
-impl From<AttParseError> for AttributeServerError {
-    fn from(err: AttParseError) -> Self {
+impl From<AttDecodeError> for AttributeServerError {
+    fn from(err: AttDecodeError) -> Self {
         AttributeServerError::AttError(err)
     }
 }
@@ -146,8 +146,8 @@ impl<'a> AttributeServer<'a> {
                     }
                 }
                 crate::PollResult::AsyncData(packet) => {
-                    let (src_handle, l2cap_packet) = L2capPacket::parse(packet)?;
-                    let packet = Att::parse(l2cap_packet)?;
+                    let (src_handle, l2cap_packet) = L2capPacket::decode(packet)?;
+                    let packet = Att::decode(l2cap_packet)?;
                     log::trace!("att: {:x?}", packet);
                     match packet {
                         Att::ReadByGroupTypeReq {

--- a/bleps/src/event.rs
+++ b/bleps/src/event.rs
@@ -1,4 +1,4 @@
-use crate::{read_to_data, Data, HciConnection};
+use crate::{Data, Error, HciConnection};
 
 #[derive(Debug)]
 pub struct Event {
@@ -71,131 +71,151 @@ const EVENT_COMMAND_COMPLETE: u8 = 0x0e;
 const EVENT_DISCONNECTION_COMPLETE: u8 = 0x05;
 const EVENT_NUMBER_OF_COMPLETED_PACKETS: u8 = 0x13;
 
-/// Parses a command and assumes the packet type (0x04) is already read.
-pub fn parse_event(connector: &dyn HciConnection) -> EventType {
-    let event = read_to_event(connector);
+impl EventType {
+    pub fn check_command_completed(self) -> Result<Self, Error> {
+        if let Self::CommandComplete {
+            num_packets: _,
+            opcode: _,
+            data,
+        } = self
+        {
+            let status = data.as_slice()[0];
+            if status != 0 {
+                return Err(Error::Failed(status));
+            }
+        }
 
-    match event.code {
-        EVENT_COMMAND_COMPLETE => {
-            let data = event.data.as_slice();
-            let num_packets = data[0];
-            let opcode = ((data[2] as u16) << 8) + data[1] as u16;
-            let data = event.data.subdata_from(3);
-            EventType::CommandComplete {
-                num_packets,
-                opcode,
-                data,
+        Ok(self)
+    }
+
+    /// Reads and decodes an event and assumes the packet type (0x04) is already read.
+    pub fn read(connector: &dyn HciConnection) -> Self {
+        let event = Event::read(connector);
+
+        match event.code {
+            EVENT_COMMAND_COMPLETE => {
+                let data = event.data.as_slice();
+                let num_packets = data[0];
+                let opcode = ((data[2] as u16) << 8) + data[1] as u16;
+                let data = event.data.subdata_from(3);
+                Self::CommandComplete {
+                    num_packets,
+                    opcode,
+                    data,
+                }
+            }
+            EVENT_DISCONNECTION_COMPLETE => {
+                let data = event.data.as_slice();
+                let status = data[0];
+                let handle = ((data[2] as u16) << 8) + data[1] as u16;
+                let reason = data[3];
+                let status = ErrorCode::from_u8(status);
+                let reason = ErrorCode::from_u8(reason);
+                Self::DisconnectComplete {
+                    handle,
+                    status,
+                    reason,
+                }
+            }
+            EVENT_NUMBER_OF_COMPLETED_PACKETS => {
+                let data = event.data.as_slice();
+                let num_handles = data[0];
+                let connection_handle = ((data[2] as u16) << 8) + data[1] as u16;
+                let completed_packet = ((data[4] as u16) << 8) + data[3] as u16;
+                Self::NumberOfCompletedPackets {
+                    number_of_connection_handles: num_handles,
+                    connection_handles: connection_handle,
+                    completed_packets: completed_packet,
+                }
+            }
+            _ => {
+                log::warn!(
+                    "Ignoring unknown event {:02x} data = {:02x?}",
+                    event.code,
+                    event.data.as_slice()
+                );
+                Self::Unknown
             }
         }
-        EVENT_DISCONNECTION_COMPLETE => {
-            let data = event.data.as_slice();
-            let status = data[0];
-            let handle = ((data[2] as u16) << 8) + data[1] as u16;
-            let reason = data[3];
-            let status = ErrorCode::from_u8(status);
-            let reason = ErrorCode::from_u8(reason);
-            EventType::DisconnectComplete {
-                handle,
-                status,
-                reason,
+    }
+
+    #[cfg(feature = "async")]
+    /// Reads and decodes an event and assumes the packet type (0x04) is already read.
+    pub async fn async_read<T>(connector: &mut T) -> Self
+    where
+        T: embedded_io::asynch::Read,
+    {
+        let event = Event::async_read(connector).await;
+
+        match event.code {
+            EVENT_COMMAND_COMPLETE => {
+                let data = event.data.as_slice();
+                let num_packets = data[0];
+                let opcode = ((data[2] as u16) << 8) + data[1] as u16;
+                let data = event.data.subdata_from(3);
+                Self::CommandComplete {
+                    num_packets,
+                    opcode,
+                    data,
+                }
             }
-        }
-        EVENT_NUMBER_OF_COMPLETED_PACKETS => {
-            let data = event.data.as_slice();
-            let num_handles = data[0];
-            let connection_handle = ((data[2] as u16) << 8) + data[1] as u16;
-            let completed_packet = ((data[4] as u16) << 8) + data[3] as u16;
-            EventType::NumberOfCompletedPackets {
-                number_of_connection_handles: num_handles,
-                connection_handles: connection_handle,
-                completed_packets: completed_packet,
+            EVENT_DISCONNECTION_COMPLETE => {
+                let data = event.data.as_slice();
+                let status = data[0];
+                let handle = ((data[2] as u16) << 8) + data[1] as u16;
+                let reason = data[3];
+                let status = ErrorCode::from_u8(status);
+                let reason = ErrorCode::from_u8(reason);
+                Self::DisconnectComplete {
+                    handle,
+                    status,
+                    reason,
+                }
             }
-        }
-        _ => {
-            log::warn!(
-                "Ignoring unknown event {:02x} data = {:02x?}",
-                event.code,
-                event.data.as_slice()
-            );
-            EventType::Unknown
+            EVENT_NUMBER_OF_COMPLETED_PACKETS => {
+                let data = event.data.as_slice();
+                let num_handles = data[0];
+                let connection_handle = ((data[2] as u16) << 8) + data[1] as u16;
+                let completed_packet = ((data[4] as u16) << 8) + data[3] as u16;
+                Self::NumberOfCompletedPackets {
+                    number_of_connection_handles: num_handles,
+                    connection_handles: connection_handle,
+                    completed_packets: completed_packet,
+                }
+            }
+            _ => {
+                log::warn!(
+                    "Ignoring unknown event {:02x} data = {:02x?}",
+                    event.code,
+                    event.data.as_slice()
+                );
+                Self::Unknown
+            }
         }
     }
 }
 
-fn read_to_event(connector: &dyn HciConnection) -> Event {
-    let code = connector.read().unwrap() as u8;
-    let len = connector.read().unwrap() as usize;
-    let data = read_to_data(connector, len);
-    Event { code, data }
-}
-
-#[cfg(feature = "async")]
-/// Parses a command and assumes the packet type (0x04) is already read.
-pub async fn async_parse_event<T>(connector: &mut T) -> EventType
-where
-    T: embedded_io::asynch::Read,
-{
-    let event = async_read_to_event(connector).await;
-
-    match event.code {
-        EVENT_COMMAND_COMPLETE => {
-            let data = event.data.as_slice();
-            let num_packets = data[0];
-            let opcode = ((data[2] as u16) << 8) + data[1] as u16;
-            let data = event.data.subdata_from(3);
-            EventType::CommandComplete {
-                num_packets,
-                opcode,
-                data,
-            }
-        }
-        EVENT_DISCONNECTION_COMPLETE => {
-            let data = event.data.as_slice();
-            let status = data[0];
-            let handle = ((data[2] as u16) << 8) + data[1] as u16;
-            let reason = data[3];
-            let status = ErrorCode::from_u8(status);
-            let reason = ErrorCode::from_u8(reason);
-            EventType::DisconnectComplete {
-                handle,
-                status,
-                reason,
-            }
-        }
-        EVENT_NUMBER_OF_COMPLETED_PACKETS => {
-            let data = event.data.as_slice();
-            let num_handles = data[0];
-            let connection_handle = ((data[2] as u16) << 8) + data[1] as u16;
-            let completed_packet = ((data[4] as u16) << 8) + data[3] as u16;
-            EventType::NumberOfCompletedPackets {
-                number_of_connection_handles: num_handles,
-                connection_handles: connection_handle,
-                completed_packets: completed_packet,
-            }
-        }
-        _ => {
-            log::warn!(
-                "Ignoring unknown event {:02x} data = {:02x?}",
-                event.code,
-                event.data.as_slice()
-            );
-            EventType::Unknown
-        }
+impl Event {
+    fn read(connector: &dyn HciConnection) -> Self {
+        let code = connector.read().unwrap() as u8;
+        let len = connector.read().unwrap() as usize;
+        let data = Data::read(connector, len);
+        Self { code, data }
     }
-}
 
-#[cfg(feature = "async")]
-async fn async_read_to_event<T>(connector: &mut T) -> Event
-where
-    T: embedded_io::asynch::Read,
-{
-    let mut buffer = [0u8];
-    let _code_len = connector.read(&mut buffer).await.unwrap();
-    let code = buffer[0];
+    #[cfg(feature = "async")]
+    async fn async_read<T>(connector: &mut T) -> Self
+    where
+        T: embedded_io::asynch::Read,
+    {
+        let mut buffer = [0u8];
+        let _code_len = connector.read(&mut buffer).await.unwrap();
+        let code = buffer[0];
 
-    let _len_len = connector.read(&mut buffer).await.unwrap();
-    let len = buffer[0] as usize;
+        let _len_len = connector.read(&mut buffer).await.unwrap();
+        let len = buffer[0] as usize;
 
-    let data = crate::asynch::read_to_data(connector, len).await;
-    Event { code, data }
+        let data = Data::async_read(connector, len).await;
+        Self { code, data }
+    }
 }

--- a/bleps/src/l2cap.rs
+++ b/bleps/src/l2cap.rs
@@ -8,12 +8,12 @@ pub struct L2capPacket {
 }
 
 #[derive(Debug)]
-pub enum L2capParseError {
+pub enum L2capDecodeError {
     Other,
 }
 
 impl L2capPacket {
-    pub fn parse(packet: AclPacket) -> Result<(u16, Self), L2capParseError> {
+    pub fn decode(packet: AclPacket) -> Result<(u16, Self), L2capDecodeError> {
         let data = packet.data.as_slice();
         let length = (data[0] as u16) + ((data[1] as u16) << 8);
         let channel = (data[2] as u16) + ((data[3] as u16) << 8);

--- a/bleps/src/l2cap.rs
+++ b/bleps/src/l2cap.rs
@@ -12,31 +12,34 @@ pub enum L2capParseError {
     Other,
 }
 
-pub fn parse_l2cap(packet: AclPacket) -> Result<(u16, L2capPacket), L2capParseError> {
-    let data = packet.data.as_slice();
-    let length = (data[0] as u16) + ((data[1] as u16) << 8);
-    let channel = (data[2] as u16) + ((data[3] as u16) << 8);
-    let payload = Data::new(&data[4..]);
+impl L2capPacket {
+    pub fn parse(packet: AclPacket) -> Result<(u16, Self), L2capParseError> {
+        let data = packet.data.as_slice();
+        let length = (data[0] as u16) + ((data[1] as u16) << 8);
+        let channel = (data[2] as u16) + ((data[3] as u16) << 8);
+        let payload = Data::new(&data[4..]);
 
-    Ok((
-        packet.handle,
-        L2capPacket {
-            length,
-            channel,
-            payload,
-        },
-    ))
-}
+        Ok((
+            packet.handle,
+            L2capPacket {
+                length,
+                channel,
+                payload,
+            },
+        ))
+    }
 
-pub fn encode_l2cap(att_data: Data) -> Data {
-    let mut data = Data::default();
-    data.append(&[0, 0]); // len set later
-    data.append(&[0x04, 0x00]); // channel
-    data.append(att_data.as_slice());
+    pub fn encode(att_data: Data) -> Data {
+        let mut data = Data::new(&[
+            0, 0, // len set later
+            0x04, 0x00, // channel
+        ]);
+        data.append(att_data.as_slice());
 
-    let len = data.len - 4;
-    data.set(0, (len & 0xff) as u8);
-    data.set(1, ((len >> 8) & 0xff) as u8);
+        let len = data.len - 4;
+        data.set(0, (len & 0xff) as u8);
+        data.set(1, ((len >> 8) & 0xff) as u8);
 
-    data
+        data
+    }
 }


### PR DESCRIPTION
Most functions now is members of corresponding types.
Functions which had named parse* but actually reads data before was renamed to read*.
Functions and types which was named parse* renamed to decode*.