### PR TITLE
Add a basic CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,6 @@ jobs:
       - run: cargo check --manifest-path=bleps/Cargo.toml
       - run: cargo check --manifest-path=bleps/Cargo.toml --features=async
       - run: cargo check --manifest-path=bleps/Cargo.toml --features=macros
+
+      - run: cargo test --manifest-path=bleps/Cargo.toml
+      - run: cargo test --manifest-path=bleps-macros/Cargo.toml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# Cancel any currently running workflows from the same PR, branch, or
+# tag when a new workflow is triggered.
+#
+# https://stackoverflow.com/a/66336834
+concurrency:
+  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@nightly
+      - uses: Swatinem/rust-cache@v2
+
+      - run: cargo check --manifest-path=bleps/Cargo.toml
+      - run: cargo check --manifest-path=bleps/Cargo.toml --features=async
+      - run: cargo check --manifest-path=bleps/Cargo.toml --features=macros


### PR DESCRIPTION
Pretty straight-forward. Only checking the `bleps` package presently, but I can add `esp32s3-serial-hci` as well if you'd like.

Successful run: https://github.com/jessebraham/bleps/actions/runs/5192559828