### PR TITLE
Update bleps to embedded-io 0.6

### DIFF
--- a/bleps/Cargo.toml
+++ b/bleps/Cargo.toml
@@ -18,8 +18,8 @@ categories = [
 
 [dependencies]
 log = "0.4.16"
-embedded-io-blocking = { package = "embedded-io", version = "0.5.0" }
-embedded-io-async = { version = "0.5.0", optional = true }
+embedded-io-blocking = { package = "embedded-io", version = "0.6.1" }
+embedded-io-async = { version = "0.6.0", optional = true }
 futures = { version = "0.3", default-features = false, optional = true }
 critical-section = { version = "1.0.1", optional = true }
 defmt = {version = "0.3", optional = true }


### PR DESCRIPTION
This update is meant to fix esp-wifi CI for https://github.com/esp-rs/esp-wifi/pull/289