### PR TITLE
Add mtu and write cmd support

### DIFF
--- a/bleps/Cargo.toml
+++ b/bleps/Cargo.toml
@@ -32,3 +32,5 @@ env_logger = "0.10.0"
 async = [ "dep:embedded-io-async", "dep:futures", "dep:critical-section" ]
 macros = [ "bleps-macros" ]
 defmt = [ "dep:defmt" ]
+mtu128 = []
+mtu256 = []

--- a/bleps/src/att.rs
+++ b/bleps/src/att.rs
@@ -10,6 +10,7 @@ const ATT_READ_BY_TYPE_RESPONSE_OPCODE: u8 = 0x09;
 pub const ATT_READ_REQUEST_OPCODE: u8 = 0x0a;
 const ATT_READ_RESPONSE_OPCODE: u8 = 0x0b;
 pub const ATT_WRITE_REQUEST_OPCODE: u8 = 0x12;
+pub const ATT_WRITE_CMD_OPCODE: u8 = 0x52;
 const ATT_WRITE_RESPONSE_OPCODE: u8 = 0x13;
 pub const ATT_EXCHANGE_MTU_REQUEST_OPCODE: u8 = 0x02;
 const ATT_EXCHANGE_MTU_RESPONSE_OPCODE: u8 = 0x03;
@@ -150,6 +151,10 @@ pub enum Att {
         handle: u16,
         data: Data,
     },
+    WriteCmd {
+        handle: u16,
+        data: Data,
+    },
     ExchangeMtu {
         mtu: u16,
     },
@@ -243,6 +248,13 @@ impl Att {
                 data.append(&payload[2..]);
 
                 Ok(Self::WriteReq { handle, data })
+            }
+            ATT_WRITE_CMD_OPCODE => {
+                let handle = (payload[0] as u16) + ((payload[1] as u16) << 8);
+                let mut data = Data::default();
+                data.append(&payload[2..]);
+
+                Ok(Self::WriteCmd { handle, data })
             }
             ATT_EXCHANGE_MTU_REQUEST_OPCODE => {
                 let mtu = (payload[0] as u16) + ((payload[1] as u16) << 8);

--- a/bleps/src/attribute_server.rs
+++ b/bleps/src/attribute_server.rs
@@ -17,6 +17,22 @@ pub const PRIMARY_SERVICE_UUID16: Uuid = Uuid::Uuid16(0x2800);
 pub const CHARACTERISTIC_UUID16: Uuid = Uuid::Uuid16(0x2803);
 pub const GENERIC_ATTRIBUTE_UUID16: Uuid = Uuid::Uuid16(0x1801);
 
+/// The base MTU that is always supported. The MTU can be upgraded
+/// per-connection. In the case of multiple connections, handling this
+/// correctly would involve keeping track of which connection was configured
+/// with which MTU. Instead of doing this, we always use the `BASE_MTU`
+/// when transmitting but in the MTU exchange we support reporting a larger MTU.
+/// This allows the client to use a larger MTU when transmitting to us, even
+/// though we always respond with the smaller MTU.
+pub const BASE_MTU: u16 = 23;
+
+#[cfg(feature = "mtu128")]
+pub const MTU: u16 = 128;
+
+#[cfg(feature = "mtu256")]
+pub const MTU: u16 = 256;
+
+#[cfg(not(any(feature = "mtu128", feature = "mtu256")))]
 pub const MTU: u16 = 23;
 
 #[derive(Debug, PartialEq)]
@@ -118,7 +134,7 @@ impl<'a> AttributeServer<'a> {
     ) -> Result<WorkResult, AttributeServerError> {
         if let Some(notification_data) = notification_data {
             let mut answer = notification_data.data;
-            answer.limit_len(MTU as usize - 3);
+            answer.limit_len(BASE_MTU as usize - 3);
             let mut data = Data::new_att_value_ntf(notification_data.handle);
             data.append(&answer.as_slice());
             self.write_att(self.src_handle, data);
@@ -173,6 +189,11 @@ impl<'a> AttributeServer<'a> {
                         Att::WriteReq { handle, data } => {
                             self.src_handle = src_handle;
                             self.handle_write_req(src_handle, handle, data);
+                        }
+
+                        Att::WriteCmd { handle, data } => {
+                            self.src_handle = src_handle;
+                            self.handle_write_cmd(src_handle, handle, data);
                         }
 
                         Att::ExchangeMtu { mtu } => {
@@ -316,13 +337,25 @@ impl<'a> AttributeServer<'a> {
 
         let response = match err {
             Ok(_) => {
-                data.limit_len(MTU as usize);
+                data.limit_len(BASE_MTU as usize);
                 data
             }
             Err(e) => Data::new_att_error_response(ATT_READ_REQUEST_OPCODE, handle, e),
         };
 
         self.write_att(src_handle, response);
+    }
+
+    fn handle_write_cmd(&mut self, src_handle: u16, handle: u16, data: Data) {
+        let mut err = Err(AttErrorCode::AttributeNotFound);
+        for att in self.attributes.iter_mut() {
+            if att.handle == handle {
+                if att.data.writable() {
+                    err = att.data.write(0, data.as_slice());
+                }
+                break;
+            }
+        }
     }
 
     fn handle_write_req(&mut self, src_handle: u16, handle: u16, data: Data) {
@@ -344,7 +377,7 @@ impl<'a> AttributeServer<'a> {
     }
 
     fn handle_exchange_mtu(&mut self, src_handle: u16, mtu: u16) {
-        log::debug!("Requested MTU {}, returning 23", mtu);
+        log::debug!("Requested MTU {mtu}, returning {MTU}");
         self.write_att(src_handle, Data::new_att_exchange_mtu_response(MTU));
         return;
     }
@@ -448,7 +481,7 @@ impl<'a> AttributeServer<'a> {
 
         let response = match err {
             Ok(_) => {
-                data.limit_len(MTU as usize - 1);
+                data.limit_len(BASE_MTU as usize - 1);
                 data
             }
             Err(e) => Data::new_att_error_response(ATT_READ_BLOB_REQ_OPCODE, handle, e),

--- a/bleps/src/lib.rs
+++ b/bleps/src/lib.rs
@@ -64,13 +64,13 @@ pub enum PollResult {
 
 #[derive(Clone, Copy)]
 pub struct Data {
-    pub data: [u8; 128],
+    pub data: [u8; 256],
     pub len: usize,
 }
 
 impl Data {
     pub fn new(bytes: &[u8]) -> Data {
-        let mut data = [0u8; 128];
+        let mut data = [0u8; 256];
         data[..bytes.len()].copy_from_slice(bytes);
         Data {
             data,
@@ -105,7 +105,7 @@ impl Data {
     }
 
     pub fn subdata_from(&self, from: usize) -> Data {
-        let mut data = [0u8; 128];
+        let mut data = [0u8; 256];
         let new_len = self.len - from;
         data[..new_len].copy_from_slice(&self.data[from..(from + new_len)]);
         Data { data, len: new_len }
@@ -330,7 +330,7 @@ impl<'a> Ble<'a> {
                     return Some(PollResult::Event(event));
                 }
                 _ => {
-                    // this is an serious error
+                    // this is a serious error
                     panic!("Unknown packet type {}", packet_type);
                 }
             },
@@ -349,7 +349,7 @@ impl<'a> Ble<'a> {
 
 impl Data {
     fn read(connector: &dyn HciConnection, len: usize) -> Self {
-        let mut data = [0u8; 128];
+        let mut data = [0u8; 256];
         for i in 0..len {
             loop {
                 match connector.read() {
@@ -591,7 +591,7 @@ pub mod asynch {
             T: embedded_io_async::Read,
         {
             let mut idx = 0;
-            let mut data = [0u8; 128];
+            let mut data = [0u8; 256];
             loop {
                 let l = connector.read(&mut data[idx..][..len]).await.unwrap();
                 idx += l;


### PR DESCRIPTION
Disclaimer: I'm coming into this knowing nothing about ble.

I've been having some trouble with bluetooth performance on my esp32c3. I think the core issue is latency, since I can't get a round trip shorter than 90ms. I haven't figured out the underlying issue, but some workarounds (which I think make sense to support anyway) are:

- support larger MTUs, so more data can be transferred per round-trip
- support write commands (i.e. without responses), because they don't round-trip nearly as often

This PR adds both of these.

I tested it out with a benchmark script that you can find [here](https://github.com/jneem/ble-bench), by sending messages of sizes 20, 100, and 200, with and without responses and with various different MTU sizes. (AFAICT, when sending without a response, the message must fit in one MTU.)

## MTU 23

|msg size   | resp  | no resp |
|----|---------|-----------------|
|20  | 227 Bps   | 1838 Bps    |
|100 | 159 Bps   | x       |
|200 | 171 Bps   | x       |

## MTU 128

| msg size    | resp  | no resp |
|-|-|-|
|20  | 227 Bps  | 1309 Bps   |
|100 | 1136 Bps | 6906 Bps   |
|200 | 746 Bps  | x       |

## MTU 256

| msg size    | resp  | no resp |
|-|-|-|
|20  | 227   Bps| 1401  Bps  |
|100 | 1132  Bps| 7418   Bps |
|200 | 2267  Bps| 18382  Bps |

18 kBps is maybe nothing to write home about, but it's a lot better than the 227 Bps I started out with!