### PR TITLE
Implement DH key check

### DIFF
--- a/bleps/src/async_attribute_server.rs
+++ b/bleps/src/async_attribute_server.rs
@@ -16,6 +16,7 @@ use crate::{
     att::Uuid,
     attribute::Attribute,
     attribute_server::{AttributeServerError, NotificationData, WorkResult},
+    Addr,
 };
 
 pub struct AttributeServer<'a, T, R: CryptoRng + RngCore>
@@ -42,14 +43,20 @@ where
         attributes: &'a mut [Attribute<'a>],
         rng: &'a mut R,
     ) -> AttributeServer<'a, T, R> {
-        AttributeServer::new_with_ltk(ble, attributes, [0u8; 6], None, rng)
+        AttributeServer::new_with_ltk(
+            ble,
+            attributes,
+            Addr::from_le_bytes(false, [0u8; 6]),
+            None,
+            rng,
+        )
     }
 
     /// Create a new instance, optionally provide an LTK
     pub fn new_with_ltk(
         ble: &'a mut Ble<T>,
         attributes: &'a mut [Attribute<'a>],
-        _local_addr: [u8; 6],
+        _local_addr: Addr,
         _ltk: Option<u128>,
         _rng: &'a mut R,
     ) -> AttributeServer<'a, T, R> {

--- a/bleps/src/attribute_server.rs
+++ b/bleps/src/attribute_server.rs
@@ -17,7 +17,7 @@ use crate::{
     command::{Command, LE_OGF, SET_ADVERTISING_DATA_OCF},
     event::EventType,
     l2cap::{L2capDecodeError, L2capPacket},
-    Ble, Data, Error,
+    Addr, Ble, Data, Error,
 };
 
 pub const PRIMARY_SERVICE_UUID16: Uuid = Uuid::Uuid16(0x2800);
@@ -159,7 +159,6 @@ bleps_dedup::dedup! {
                         status: _status,
                         handle: _,
                         role: _,
-                        peer_address_type: _,
                         peer_address: _peer_address,
                         interval: _,
                         latency: _,
@@ -564,14 +563,20 @@ impl<'a, R: CryptoRng + RngCore> AttributeServer<'a, R> {
         attributes: &'a mut [Attribute<'a>],
         rng: &'a mut R,
     ) -> AttributeServer<'a, R> {
-        AttributeServer::new_with_ltk(ble, attributes, [0u8; 6], None, rng)
+        AttributeServer::new_with_ltk(
+            ble,
+            attributes,
+            Addr::from_le_bytes(false, [0u8; 6]),
+            None,
+            rng,
+        )
     }
 
     /// Create a new instance, optionally provide an LTK
     pub fn new_with_ltk(
         ble: &'a mut Ble<'a>,
         attributes: &'a mut [Attribute<'a>],
-        _local_addr: [u8; 6],
+        _local_addr: Addr,
         _ltk: Option<u128>,
         _rng: &'a mut R,
     ) -> AttributeServer<'a, R> {

--- a/bleps/src/crypto.rs
+++ b/bleps/src/crypto.rs
@@ -1,5 +1,7 @@
 // This file contains code from Blackrock User-Mode Bluetooth LE Library (https://github.com/mxk/burble)
 
+use crate::Addr;
+
 use cmac::digest;
 use p256::{ecdh, elliptic_curve::rand_core};
 use rand_core::CryptoRng;
@@ -96,28 +98,10 @@ impl From<&Key> for u128 {
     }
 }
 
-/// 56-bit device address in big-endian byte order used by [`DHKey::f5`] and
-/// [`MacKey::f6`] functions ([Vol 3] Part H, Section 2.2.7 and 2.2.8).
-#[derive(Clone, Copy, Debug)]
-#[must_use]
-#[repr(transparent)]
-pub struct Addr(pub [u8; 7]);
-
-impl Addr {
-    /// Creates a device address from a little-endian byte array.
-    #[inline]
-    pub fn from_le_bytes(is_random: bool, mut v: [u8; 6]) -> Self {
-        v.reverse();
-        let mut a = [0; 7];
-        a[0] = u8::from(is_random);
-        a[1..].copy_from_slice(&v);
-        Self(a)
-    }
-}
-
 /// Concatenated `AuthReq`, OOB data flag, and IO capability parameters used by
 /// [`MacKey::f6`] function ([Vol 3] Part H, Section 2.2.8).
 #[repr(transparent)]
+#[derive(Clone, Copy, Debug)]
 pub struct IoCap([u8; 3]);
 
 impl IoCap {

--- a/bleps/src/event.rs
+++ b/bleps/src/event.rs
@@ -1,4 +1,4 @@
-use crate::{Data, Error, HciConnection};
+use crate::{Addr, Data, Error, HciConnection};
 
 #[derive(Debug)]
 pub struct Event {
@@ -27,8 +27,7 @@ pub enum EventType {
         status: u8,
         handle: u16,
         role: u8,
-        peer_address_type: u8,
-        peer_address: [u8; 6],
+        peer_address: Addr,
         interval: u16,
         latency: u16,
         timeout: u16,
@@ -156,8 +155,8 @@ impl EventType {
                         let status = data[0];
                         let handle = ((data[2] as u16) << 8) + data[1] as u16;
                         let role = data[3];
-                        let peer_address_type = data[4];
-                        let peer_address = data[5..][..6].try_into().unwrap();
+                        let peer_address =
+                            Addr::from_le_bytes(data[4] != 0, data[5..][..6].try_into().unwrap());
                         let interval = ((data[2] as u16) << 8) + data[1] as u16;
                         let latency = ((data[2] as u16) << 8) + data[1] as u16;
                         let timeout = ((data[2] as u16) << 8) + data[1] as u16;
@@ -166,7 +165,6 @@ impl EventType {
                             status,
                             handle,
                             role,
-                            peer_address_type,
                             peer_address,
                             interval,
                             latency,
@@ -257,8 +255,8 @@ impl EventType {
                         let status = data[0];
                         let handle = ((data[2] as u16) << 8) + data[1] as u16;
                         let role = data[3];
-                        let peer_address_type = data[4];
-                        let peer_address = data[5..][..6].try_into().unwrap();
+                        let peer_address =
+                            Addr::from_le_bytes(data[4] != 0, data[5..][..6].try_into().unwrap());
                         let interval = ((data[2] as u16) << 8) + data[1] as u16;
                         let latency = ((data[2] as u16) << 8) + data[1] as u16;
                         let timeout = ((data[2] as u16) << 8) + data[1] as u16;
@@ -267,7 +265,6 @@ impl EventType {
                             status,
                             handle,
                             role,
-                            peer_address_type,
                             peer_address,
                             interval,
                             latency,

--- a/bleps/src/lib.rs
+++ b/bleps/src/lib.rs
@@ -63,6 +63,25 @@ impl defmt::Format for Error {
     }
 }
 
+/// 56-bit device address in big-endian byte order used by [`DHKey::f5`] and
+/// [`MacKey::f6`] functions ([Vol 3] Part H, Section 2.2.7 and 2.2.8).
+#[derive(Clone, Copy, Debug)]
+#[must_use]
+#[repr(transparent)]
+pub struct Addr(pub [u8; 7]);
+
+impl Addr {
+    /// Creates a device address from a little-endian byte array.
+    #[inline]
+    pub fn from_le_bytes(is_random: bool, mut v: [u8; 6]) -> Self {
+        v.reverse();
+        let mut a = [0; 7];
+        a[0] = u8::from(is_random);
+        a[1..].copy_from_slice(&v);
+        Self(a)
+    }
+}
+
 #[derive(Debug)]
 pub enum PollResult {
     Event(EventType),

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -11,7 +11,7 @@ use bleps::{
         create_advertising_data, AdStructure, BR_EDR_NOT_SUPPORTED, LE_GENERAL_DISCOVERABLE,
     },
     attribute_server::{AttributeServer, NotificationData, WorkResult},
-    gatt, Ble, HciConnector,
+    gatt, Addr, Ble, HciConnector,
 };
 use embedded_io_adapters::std::FromStd;
 use embedded_io_blocking::{Error, ErrorType, Read, Write};
@@ -63,7 +63,7 @@ fn main() {
 
         println!("{:?}", ble.init());
 
-        let local_addr = ble.cmd_read_br_addr().unwrap();
+        let local_addr = Addr::from_le_bytes(false, ble.cmd_read_br_addr().unwrap());
 
         println!("{:?}", ble.cmd_set_le_advertising_parameters());
         println!(


### PR DESCRIPTION
The security manager now stores the extra information needed to perform the DH key check. In order to handle random addresses, the stored addresses that were there before are changed to `Addr`. The nonces are also changed to `Nonce` to reduce conversions.