### PR TITLE
Use the negotiated mtu for read requests

### DIFF
--- a/bleps/src/async_attribute_server.rs
+++ b/bleps/src/async_attribute_server.rs
@@ -17,6 +17,7 @@ where
 {
     pub(crate) ble: &'a mut Ble<T>,
     pub(crate) src_handle: u16,
+    pub(crate) mtu: u16,
     pub(crate) attributes: &'a mut [Attribute<'a>],
 }
 
@@ -43,6 +44,7 @@ where
         AttributeServer {
             ble,
             src_handle: 0,
+            mtu: crate::attribute_server::BASE_MTU,
             attributes,
         }
     }


### PR DESCRIPTION
This uses the negotiated mtu for read requests.

It also changes the truncation in `handle_read_blob`, which I think was off by one before (because we're working directly with the returned data, unlike in `do_work_with_notification`). Before this change, long (larger-than-mtu) reads were getting truncated at exactly two packets.