### PR TITLE
Add support for characteristic descriptors and small fixes

### DIFF
--- a/bleps-macros/tests/macro_test.rs
+++ b/bleps-macros/tests/macro_test.rs
@@ -94,3 +94,39 @@ fn test4() {
     println!("{}", my_characteristic_handle);
     println!("{}", my_characteristic_notify_enable_handle);
 }
+
+#[test]
+fn test5() {
+    let char_value = b"Hello!";
+
+    let mut my_read_function = |_offset: usize, data: &mut [u8]| {
+        data[..5].copy_from_slice(&b"Hola!"[..]);
+        5
+    };
+    let mut my_write_function = |_offset, data: &[u8]| {
+        println!("{:?}", data);
+    };
+
+    let desc_value = b"Hallo!";
+
+    gatt!([service {
+        uuid: "9e7312e0-2354-11eb-9f10-fbc30a62cf38",
+        characteristics: [characteristic {
+            uuid: "9e7312e0-2354-11eb-9f10-fbc30a62cf38",
+            value: char_value,
+            descriptors: [
+                descriptor {
+                    uuid: "9e7312e0-0001-11eb-9f10-fbc30a62cf38",
+                    read: my_read_function,
+                    write: my_write_function,
+                },
+                descriptor {
+                    uuid: "9e7312e0-0002-11eb-9f10-fbc30a62cf38",
+                    value: desc_value,
+                },
+            ],
+        },],
+    },]);
+
+    println!("{:x?}", gatt_attributes);
+}

--- a/bleps/src/att.rs
+++ b/bleps/src/att.rs
@@ -200,7 +200,7 @@ impl Att {
                 let group_type = if payload.len() == 6 {
                     Uuid::Uuid16((payload[4] as u16) + ((payload[5] as u16) << 8))
                 } else if payload.len() == 20 {
-                    let uuid = payload[4..21]
+                    let uuid = payload[4..20]
                         .try_into()
                         .map_err(|_| AttDecodeError::Other)?;
                     Uuid::Uuid128(uuid)
@@ -221,7 +221,7 @@ impl Att {
                 let attribute_type = if payload.len() == 6 {
                     Uuid::Uuid16((payload[4] as u16) + ((payload[5] as u16) << 8))
                 } else if payload.len() == 20 {
-                    let uuid = payload[4..21]
+                    let uuid = payload[4..20]
                         .try_into()
                         .map_err(|_| AttDecodeError::Other)?;
                     Uuid::Uuid128(uuid)


### PR DESCRIPTION
#### Added

- Support in the gatt macro for arbitrary characteristic descriptors (gatt attributes following characteristic declaration).

#### Fixed

- Inconsistent assumption of characteristic descriptors ordering manifesting in dropping characteristic notifications. This happened because `bleps`'s attribute server assumed that the only first most descriptor of characteristic could be "Client Characteristic Configuration" Descriptor. Which wasn't consistent with the gatt macro.
- Off-by-one error resulting in panic when any gatt attribute is read by type.
