### PR TITLE
Add notify_cb option to `gatt!` characteristics.

### DIFF
--- a/bleps-macros/tests/macro_test.rs
+++ b/bleps-macros/tests/macro_test.rs
@@ -130,3 +130,30 @@ fn test5() {
 
     println!("{:x?}", gatt_attributes);
 }
+
+#[test]
+fn test6() {
+    let mut my_read_function = |_offset: usize, data: &mut [u8]| {
+        data[..5].copy_from_slice(&b"Ciao!"[..]);
+        5
+    };
+    let mut my_write_function = |_offset, data: &[u8]| {
+        println!("{:?}", data);
+    };
+    let mut my_notify = |enabled: bool| {
+        println!("enabled = {enabled}");
+    };
+
+    gatt!([service {
+        uuid: "9e7312e0-2354-11eb-9f10-fbc30a62cf38",
+        characteristics: [characteristic {
+            uuid: "9e7312e0-2354-11eb-9f10-fbc30a62cf38",
+            notify: true,
+            notify_cb: my_notify,
+            read: my_read_function,
+            write: my_write_function,
+        },],
+    },]);
+
+    println!("{:x?}", gatt_attributes);
+}

--- a/bleps/tests/test_ble.rs
+++ b/bleps/tests/test_ble.rs
@@ -641,7 +641,7 @@ fn attribute_server_discover_two_services() {
     let mut char_att_data = &char_data;
     let char = Attribute::new(CHARACTERISTIC_UUID16, &mut char_att_data);
 
-    let mut custom_char_att_data = (&mut rf1, &mut wf1);
+    let mut custom_char_att_data = (&mut rf1, &mut wf1, ());
     let custom_char_att_data_attr = Attribute::new(
         Uuid::Uuid128([
             0xC9, 0x15, 0x15, 0x96, 0x54, 0x56, 0x64, 0xB3, 0x38, 0x45, 0x26, 0x5D, 0xF1, 0x62,
@@ -681,7 +681,7 @@ fn attribute_server_discover_two_services() {
     let mut char_att_data2 = &char_data2;
     let char2 = Attribute::new(CHARACTERISTIC_UUID16, &mut char_att_data2);
 
-    let mut custom_char_att_data2 = (&mut rf2, &mut wf2);
+    let mut custom_char_att_data2 = (&mut rf2, &mut wf2, ());
     let custom_char_att_data_attr2 = Attribute::new(
         Uuid::Uuid128([
             0xC9, 0x15, 0x15, 0x96, 0x54, 0x56, 0x64, 0xB3, 0x38, 0x45, 0x26, 0x5D, 0xF1, 0x62,


### PR DESCRIPTION
Being able to take action when a characteristic's notifications are enabled are disabled is useful when the data source needs some action to be taken to start or stop the data source like enabling interrupts or powering on a sensor.