### PR TITLE
According to the spec V4PE 5.2 all parameters are sent little-endian

### DIFF
--- a/bleps/src/command.rs
+++ b/bleps/src/command.rs
@@ -95,8 +95,8 @@ impl<'a> Command<'a> {
                     .write_into(&mut data[1..]);
 
                 let mut adv_params = Data::new(&[]);
-                adv_params.append(&params.advertising_interval_min.to_be_bytes());
-                adv_params.append(&params.advertising_interval_max.to_be_bytes());
+                adv_params.append(&params.advertising_interval_min.to_le_bytes());
+                adv_params.append(&params.advertising_interval_max.to_le_bytes());
                 adv_params.append(&[params.advertising_type as u8]);
                 adv_params.append(&[params.own_address_type as u8]);
                 adv_params.append(&[params.peer_address_type as u8]);


### PR DESCRIPTION
Related to #49, I looked it up and found in the Bluetooth 5.3 specification Vol 4 Part E 5.2
```
Unless noted otherwise, all parameter values are sent and received in little-
endian format (i.e. for multi-octet parameters the rightmost (Least Significant
Octet) is transmitted first.
```
You mentioned other instances that might need to be fixed, but I couldn't find any.